### PR TITLE
Add python-multipart to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 camoufox
 playwright
 httpx
+python-multipart


### PR DESCRIPTION
Form data requires "python-multipart" to be installed.