### PR TITLE
Fix split arena-auth cookies + optional API key auth

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2824,9 +2824,12 @@ def _capture_ephemeral_arena_auth_token_from_cookies(cookies: list[dict]) -> Non
                 if not is_arena_auth_token_expired(combined, skew_seconds=0):
                     EPHEMERAL_ARENA_AUTH_TOKEN = combined
                     return
+                fallback = combined  # It's expired, but a candidate for fallback.
             except Exception:
+                # If expiry check fails, treat it as a valid token and return.
                 EPHEMERAL_ARENA_AUTH_TOKEN = combined
                 return
+
 
         for cookie in cookies or []:
             if str(cookie.get("name") or "") != "arena-auth-prod-v1":


### PR DESCRIPTION
Google OAuth can split arena-auth-prod-v1 into .0/.1 cookies (size limit). This combines them and persists to config for session recovery.  Also: API keys now optional - if none configured, anonymous access allowed.