### PR TITLE
Enable OpenAI and Copilot in oh-my-opencode install

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -156,7 +156,7 @@ jobs:
           opencode --version
 
           # Run local oh-my-opencode install (uses built dist)
-          bun run oh-my-opencode/dist/cli/index.js install --no-tui --claude=no --openai=no --gemini=no --copilot=no
+          bun run oh-my-opencode/dist/cli/index.js install --no-tui --claude=no --openai=yes --gemini=no --copilot=yes
 
           # Override plugin to use local file reference
           OPENCODE_JSON=~/.config/opencode/opencode.json


### PR DESCRIPTION
This pull request makes a small adjustment to the workflow configuration. The change enables the use of the OpenAI and Copilot plugins during the local `oh-my-opencode` installation step in the GitHub Actions workflow. No other significant changes are included.

- Enabled the `openai` and `copilot` plugins (set to `yes`) in the `oh-my-opencode` install command in `.github/workflows/cloudwaddie-agent.yml`