### PR TITLE
Disable OpenAI and Copilot options in installation

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -156,7 +156,7 @@ jobs:
           opencode --version
 
           # Run local oh-my-opencode install (uses built dist)
-          bun run oh-my-opencode/dist/cli/index.js install --no-tui --claude=no --openai=yes --gemini=no --copilot=yes
+          bun run oh-my-opencode/dist/cli/index.js install --no-tui --claude=no --openai=false --gemini=no --copilot=false
 
           # Override plugin to use local file reference
           OPENCODE_JSON=~/.config/opencode/opencode.json


### PR DESCRIPTION
For now, as free models are the only working ones I'll switch temporarily.