### PR TITLE
Fix premium providers not working

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -155,8 +155,29 @@ jobs:
           fi
           opencode --version
 
-          # Run local oh-my-opencode install (uses built dist)
-          bun run oh-my-opencode/dist/cli/index.js install --no-tui --claude=no --openai=no --gemini=no --copilot=no
+          CLAUDE_FLAG="--claude=no"
+          OPENAI_FLAG="--openai=no"
+          GEMINI_FLAG="--gemini=no"
+          COPILOT_FLAG="--copilot=no"
+
+          if [[ -n "$OPENCODE_AUTH_JSON" ]]; then
+            mkdir -p ~/.local/share/opencode
+            echo "$OPENCODE_AUTH_JSON" > ~/.local/share/opencode/auth.json
+            chmod 600 ~/.local/share/opencode/auth.json
+
+            if echo "$OPENCODE_AUTH_JSON" | jq -e '.anthropic' > /dev/null 2>&1; then
+              CLAUDE_FLAG="--claude=yes"
+            fi
+            if echo "$OPENCODE_AUTH_JSON" | jq -e '.openai' > /dev/null 2>&1; then
+              OPENAI_FLAG="--openai=yes"
+            fi
+            if echo "$OPENCODE_AUTH_JSON" | jq -e '.google' > /dev/null 2>&1; then
+              GEMINI_FLAG="--gemini=yes"
+            fi
+            COPILOT_FLAG="--copilot=yes"
+          fi
+
+          bun run oh-my-opencode/dist/cli/index.js install --no-tui $CLAUDE_FLAG $OPENAI_FLAG $GEMINI_FLAG $COPILOT_FLAG
 
           # Override plugin to use local file reference
           OPENCODE_JSON=~/.config/opencode/opencode.json
@@ -165,14 +186,8 @@ jobs:
             .plugin = [.plugin[] | select(. != "oh-my-opencode")] + [$path]
           ' "$OPENCODE_JSON" > /tmp/oc.json && mv /tmp/oc.json "$OPENCODE_JSON"
 
-          # Configure auth if provided, otherwise use free models
-          if [[ -n "$OPENCODE_AUTH_JSON" ]]; then
-            mkdir -p ~/.local/share/opencode
-            echo "$OPENCODE_AUTH_JSON" > ~/.local/share/opencode/auth.json
-            chmod 600 ~/.local/share/opencode/auth.json
-          else
+          if [[ -z "$OPENCODE_AUTH_JSON" ]]; then
             echo "No auth provided - using free OpenCode models"
-            # Set default model to free tier
             jq '.model = "opencode/big-pickle"' "$OPENCODE_JSON" > /tmp/oc.json && mv /tmp/oc.json "$OPENCODE_JSON"
           fi
 


### PR DESCRIPTION
## Summary

The workflow was hardcoding all providers to "no" in the install command, which overrode any premium credentials set in `OPENCODE_AUTH_JSON`.

## Root Cause

The install command was running with:
```bash
bun run oh-my-opencode/dist/cli/index.js install --no-tui --claude=no --openai=no --gemini=no --copilot=no
```

This disabled all providers regardless of what credentials were provided.

## Fix Applied

1. **Write auth.json BEFORE install** - so providers are available during config generation
2. **Parse OPENCODE_AUTH_JSON** to detect which providers have credentials:
   - If auth contains `"anthropic"` → enables `--claude=yes`
   - If auth contains `"openai"` → enables `--openai=yes`
   - If auth contains `"google"` → enables `--gemini=yes`
   - Enables copilot as fallback when any provider is available

3. **Run install with correct flags** based on available auth

## Testing

Re-run the workflow with `OPENCODE_AUTH_JSON` secret containing your provider credentials. The workflow should now correctly use your premium models.

Refs: CloudWaddie/actions-agent#56