### PR TITLE
fix: clear provider caches after writing auth for premium models

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -167,6 +167,8 @@ jobs:
             echo "$OPENCODE_AUTH_JSON" > ~/.local/share/opencode/auth.json
             chmod 600 ~/.local/share/opencode/auth.json
 
+            rm -rf ~/.cache/oh-my-opencode/connected-providers.json ~/.cache/oh-my-opencode/provider-models.json 2>/dev/null || true
+
             # Detect which providers have credentials
             if echo "$OPENCODE_AUTH_JSON" | jq -e '.anthropic' > /dev/null 2>&1; then
               CLAUDE_FLAG="--claude=yes"


### PR DESCRIPTION
## Summary

- Clear oh-my-opencode provider caches after writing auth.json so premium models are detected correctly
- Without this, stale cache prevents premium models from being found even with valid credentials

Fixes CloudWaddie/actions-agent#56