### PR TITLE
fix: default provider flags to no for premium model detection

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -157,9 +157,9 @@ jobs:
 
           # Configure auth FIRST (before install) so providers can be detected
           CLAUDE_FLAG="--claude=no"
-          OPENAI_FLAG="--openai=yes"
+          OPENAI_FLAG="--openai=no"
           GEMINI_FLAG="--gemini=no"
-          COPILOT_FLAG="--copilot=yes"
+          COPILOT_FLAG="--copilot=no"
 
           if [[ -n "$OPENCODE_AUTH_JSON" ]]; then
             # Write auth.json so install can detect providers


### PR DESCRIPTION
## Summary

The workflow was hardcoding `OPENAI_FLAG="--openai=yes"` and `COPILOT_FLAG="--copilot=yes"` as defaults, which caused premium models to fail with "Model not found" errors.

## Root Cause

When the defaults are set to `--yes` even without auth, the install runs expecting providers to be available. At runtime, when the provider isn't actually connected (due to invalid/missing auth), the model resolution fails.

## Fix

- Start all provider flags with `--no` as defaults (matching actions-agent)
- Only enable providers when auth credentials are detected in `OPENCODE_AUTH_JSON`
- This ensures the model config is generated correctly based on actual available providers

## Testing

Re-run the workflow after merging - premium models should work correctly now.