### PR TITLE
fix: enable OpenAI/Copilot model selection when providers detected

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -157,9 +157,9 @@ jobs:
 
           # Configure auth FIRST (before install) so providers can be detected
           CLAUDE_FLAG="--claude=no"
-          OPENAI_FLAG="--openai=yes"
+          OPENAI_FLAG="--openai=no"
           GEMINI_FLAG="--gemini=no"
-          COPILOT_FLAG="--copilot=yes"
+          COPILOT_FLAG="--copilot=no"
 
           if [[ -n "$OPENCODE_AUTH_JSON" ]]; then
             # Write auth.json so install can detect providers
@@ -204,6 +204,9 @@ jobs:
           # Configure model for free tier if no auth
           if [[ -z "$OPENCODE_AUTH_JSON" ]]; then
             jq '.model = "opencode/big-pickle"' "$OPENCODE_JSON" > /tmp/oc.json && mv /tmp/oc.json "$OPENCODE_JSON"
+          elif [[ "$OPENAI_FLAG" == "--openai=yes" ]] || [[ "$COPILOT_FLAG" == "--copilot=yes" ]]; then
+            echo "OpenAI/Copilot available - using GPT-4o for Sisyphus"
+            jq '.model = "opencode/gpt-4o"' "$OPENCODE_JSON" > /tmp/oc.json && mv /tmp/oc.json "$OPENCODE_JSON"
           fi
 
           # Configure oh-my-opencode prompt_append with ultrawork mode


### PR DESCRIPTION
## Summary
- Fix default provider flags to start with `--no` instead of `--yes`
- Add model configuration to use GPT-4o when OpenAI/Copilot is available (not Claude)

This fixes the issue where premium models weren't working because the workflow was trying to use Claude models even when the user wanted to use OpenAI/Copilot.

## Changes
1. Changed default flags from `--openai=yes --copilot=yes` to `--openai=no --copilot=no`
2. Added model configuration: when OpenAI or Copilot is enabled, use `opencode/gpt-4o` instead of defaulting to Claude

## Related
- Fixes #56 in actions-agent