### PR TITLE
fix: add missing import re to recaptcha.py

### DIFF
--- a/src/recaptcha.py
+++ b/src/recaptcha.py
@@ -15,6 +15,7 @@ accessed via _m() late-import of main so test patches remain effective.
 
 import asyncio
 import os
+import re
 import shutil
 from datetime import datetime, timedelta, timezone
 from pathlib import Path


### PR DESCRIPTION
## Summary

Fixes critical runtime error identified in PR #85 code review.

## Fix

Added missing `import re` to `src/recaptcha.py`. The file uses `re.search()` and `re.error` but the `re` module was not imported, causing a `NameError` at runtime.

## Changes

- `src/recaptcha.py`: Added `import re` to the imports section

## Testing

- Syntax check: `python -c "import ast; ast.parse(open('src/recaptcha.py').read())"` passes

## Related

- PR #85 code review flagged this issue