### PR TITLE
fix(recaptcha): use main_world_eval=True for cross-origin object access

### DIFF
--- a/src/recaptcha.py
+++ b/src/recaptcha.py
@@ -608,9 +608,12 @@ async def get_recaptcha_v3_token() -> Optional[str]:
             _m().RECAPTCHA_EXPIRY = datetime.now(timezone.utc) + timedelta(seconds=110)
             return chrome_token
 
-        # Use isolated world (main_world_eval=False) to avoid execution context destruction issues.
+        # Use main world (main_world_eval=True) to access wrappedJSObject properly.
+        # This is required to bypass Firefox's Xray wrapper for cross-origin reCAPTCHA objects.
         # We will access the main world objects via window.wrappedJSObject.
-        async with _m().AsyncCamoufox(headless=True, main_world_eval=False) as browser:
+        async with _m().AsyncCamoufox(headless=True, main_world_eval=True) as browser:
+
+
             context = await browser.new_context()
             if cf_clearance:
                 await context.add_cookies([{


### PR DESCRIPTION
## Summary

- Fixes 503 Service Unavailable error caused by Firefox's Xray/Xpert wrapper security feature
- Changes `main_world_eval=False` to `main_world_eval=True` in Camoufox browser instantiation for reCAPTCHA token retrieval

## Root Cause

The error `❌ JS Sync Error: SYNC_ERROR: Error: Permission denied to access object` occurs because:

1. Isolated world execution (`main_world_eval=False`) cannot properly access `window.wrappedJSObject`
2. Firefox's Xray wrapper blocks cross-origin reCAPTCHA object access from isolated worlds
3. This prevents the side-channel token retrieval from working

## Fix

Uses main world execution (`main_world_eval=True`) which allows proper access to `window.wrappedJSObject` to bypass Firefox's Xray wrapper for cross-origin reCAPTCHA objects.

This matches the pattern already used in `transport.py` (`fetch_lmarena_stream_via_camoufox`), which works correctly.

## Related

- Fixes #89
- Related to #54 and #88 (same error family - reCAPTCHA token acquisition failures)