### PR TITLE
fix(recaptcha): use main_world_eval=True to fix Xray wrapper access error

### DIFF
--- a/src/recaptcha.py
+++ b/src/recaptcha.py
@@ -608,9 +608,9 @@ async def get_recaptcha_v3_token() -> Optional[str]:
             _m().RECAPTCHA_EXPIRY = datetime.now(timezone.utc) + timedelta(seconds=110)
             return chrome_token
 
-        # Use isolated world (main_world_eval=False) to avoid execution context destruction issues.
-        # We will access the main world objects via window.wrappedJSObject.
-        async with _m().AsyncCamoufox(headless=True, main_world_eval=False) as browser:
+        # Use main world (main_world_eval=True) to access wrappedJSObject properly.
+        # This bypasses Firefox's Xray wrapper for cross-origin reCAPTCHA objects.
+        async with _m().AsyncCamoufox(headless=True, main_world_eval=True) as browser:
             context = await browser.new_context()
             if cf_clearance:
                 await context.add_cookies([{


### PR DESCRIPTION
## Summary

Fixes the "Permission denied to access object" error that occurs during reCAPTCHA token retrieval in side-channel mode.

## Root Cause

Firefox's **Xray/Xpert wrapper security feature** blocks cross-origin reCAPTCHA object access when using isolated world execution (`main_world_eval=False`). The code relies on `window.wrappedJSObject` to bypass this, but this pattern **does not work in isolated worlds**.

## The Fix

Changed `main_world_eval=False` to `main_world_eval=True` in `src/recaptcha.py` line 613.

This aligns with:
- `src/main.py` (line 739) - already uses `main_world_eval=True`
- `src/transport.py` (lines 1161, 1809, 1814, 1827) - already uses `main_world_eval=True`

## Why This Works

`main_world_eval=True` runs scripts in the main world, allowing proper access to `window.wrappedJSObject` to bypass Firefox's Xray wrapper for cross-origin reCAPTCHA objects.

## Testing

@amadeo10000 Please test this fix and let us know if it resolves your 503 error!

```bash
# Pull from my fork
git fetch origin
git checkout fix/main_world_eval_recaptcha
# Or pull the latest from main which should include this after merge
```

## Related Issues

- #89 - Error 503 Service Unavailable
- #88 - HTTP 403 Forbidden  
- #54 - 500 Internal Server Error

All three issues share the same root cause: reCAPTCHA token acquisition failures due to Firefox Xray wrapper.