### PR TITLE
fix(playwright): remove invalid path from domain-based cookies

### DIFF
--- a/src/recaptcha.py
+++ b/src/recaptcha.py
@@ -446,17 +446,17 @@ async def get_recaptcha_v3_token_with_chrome(config: dict) -> Optional[str]:
     recaptcha_sitekey, recaptcha_action = get_recaptcha_settings(config)
 
     cookies = []
+    # When using domain, do NOT include path - they're mutually exclusive in Playwright
     if cf_clearance:
-        cookies.append({"name": "cf_clearance", "value": cf_clearance, "domain": ".lmarena.ai", "path": "/"})
+        cookies.append({"name": "cf_clearance", "value": cf_clearance, "domain": ".lmarena.ai"})
     if cf_bm:
-        cookies.append({"name": "__cf_bm", "value": cf_bm, "domain": ".lmarena.ai", "path": "/"})
+        cookies.append({"name": "__cf_bm", "value": cf_bm, "domain": ".lmarena.ai"})
     if cfuvid:
-        cookies.append({"name": "_cfuvid", "value": cfuvid, "domain": ".lmarena.ai", "path": "/"})
+        cookies.append({"name": "_cfuvid", "value": cfuvid, "domain": ".lmarena.ai"})
     if provisional_user_id:
         cookies.append(
-            {"name": "provisional_user_id", "value": provisional_user_id, "domain": ".lmarena.ai", "path": "/"}
+            {"name": "provisional_user_id", "value": provisional_user_id, "domain": ".lmarena.ai"}
         )
-
     async with async_playwright() as p:
         context = await p.chromium.launch_persistent_context(
             user_data_dir=str(profile_dir),

--- a/src/transport.py
+++ b/src/transport.py
@@ -466,8 +466,8 @@ def _provisional_user_id_cookie_specs(provisional_user_id: str, *, page_url: Opt
     for origin in _arena_origin_candidates(page_url):
         specs.append({"name": "provisional_user_id", "value": value, "url": origin, "path": "/"})
     for domain in (".lmarena.ai", ".arena.ai"):
-        specs.append({"name": "provisional_user_id", "value": value, "domain": domain, "path": "/"})
-    return specs
+        # When using domain, do NOT include path - they're mutually exclusive in Playwright
+        specs.append({"name": "provisional_user_id", "value": value, "domain": domain})
 
 
 async def _get_arena_context_cookies(context, *, page_url: Optional[str] = None) -> list[dict]:
@@ -633,19 +633,19 @@ async def fetch_lmarena_stream_via_chrome(
     grecaptcha_cookie = str(cookie_map.get("_GRECAPTCHA") or "").strip()
 
     desired_cookies: list[dict] = []
+    # When using domain, do NOT include path - they're mutually exclusive in Playwright
     if cf_clearance:
-        desired_cookies.append({"name": "cf_clearance", "value": cf_clearance, "domain": ".lmarena.ai", "path": "/"})
+        desired_cookies.append({"name": "cf_clearance", "value": cf_clearance, "domain": ".lmarena.ai"})
     if cf_bm:
-        desired_cookies.append({"name": "__cf_bm", "value": cf_bm, "domain": ".lmarena.ai", "path": "/"})
+        desired_cookies.append({"name": "__cf_bm", "value": cf_bm, "domain": ".lmarena.ai"})
     if cfuvid:
-        desired_cookies.append({"name": "_cfuvid", "value": cfuvid, "domain": ".lmarena.ai", "path": "/"})
+        desired_cookies.append({"name": "_cfuvid", "value": cfuvid, "domain": ".lmarena.ai"})
     if provisional_user_id:
         desired_cookies.append(
-            {"name": "provisional_user_id", "value": provisional_user_id, "domain": ".lmarena.ai", "path": "/"}
+            {"name": "provisional_user_id", "value": provisional_user_id, "domain": ".lmarena.ai"}
         )
     if grecaptcha_cookie:
-        desired_cookies.append({"name": "_GRECAPTCHA", "value": grecaptcha_cookie, "domain": ".lmarena.ai", "path": "/"})
-    if auth_token:
+        desired_cookies.append({"name": "_GRECAPTCHA", "value": grecaptcha_cookie, "domain": ".lmarena.ai"})
         desired_cookies.extend(_arena_auth_cookie_specs(auth_token))
 
     user_agent = _m().normalize_user_agent_value(config.get("user_agent"))
@@ -1120,21 +1120,21 @@ async def fetch_lmarena_stream_via_camoufox(
     grecaptcha_cookie = str(cookie_map.get("_GRECAPTCHA") or "").strip()
 
     desired_cookies: list[dict] = []
+    # When using domain, do NOT include path - they're mutually exclusive in Playwright
     if cf_clearance:
-        desired_cookies.append({"name": "cf_clearance", "value": cf_clearance, "domain": ".lmarena.ai", "path": "/"})
+        desired_cookies.append({"name": "cf_clearance", "value": cf_clearance, "domain": ".lmarena.ai"})
     if cf_bm:
-        desired_cookies.append({"name": "__cf_bm", "value": cf_bm, "domain": ".lmarena.ai", "path": "/"})
+        desired_cookies.append({"name": "__cf_bm", "value": cf_bm, "domain": ".lmarena.ai"})
     if cfuvid:
-        desired_cookies.append({"name": "_cfuvid", "value": cfuvid, "domain": ".lmarena.ai", "path": "/"})
+        desired_cookies.append({"name": "_cfuvid", "value": cfuvid, "domain": ".lmarena.ai"})
     if provisional_user_id:
         desired_cookies.append(
-            {"name": "provisional_user_id", "value": provisional_user_id, "domain": ".lmarena.ai", "path": "/"}
+            {"name": "provisional_user_id", "value": provisional_user_id, "domain": ".lmarena.ai"}
         )
     if grecaptcha_cookie:
-        desired_cookies.append({"name": "_GRECAPTCHA", "value": grecaptcha_cookie, "domain": ".lmarena.ai", "path": "/"})
+        desired_cookies.append({"name": "_GRECAPTCHA", "value": grecaptcha_cookie, "domain": ".lmarena.ai"})
     if auth_token:
         desired_cookies.extend(_arena_auth_cookie_specs(auth_token))
-
     user_agent = _m().normalize_user_agent_value(config.get("user_agent"))
 
     fetch_url = _normalize_userscript_proxy_url(url)
@@ -1854,17 +1854,17 @@ async def camoufox_proxy_worker():
                 provisional_user_id = str(cfg.get("provisional_user_id") or cookie_map.get("provisional_user_id") or "").strip()
 
                 desired_cookies: list[dict] = []
+                # When using domain, do NOT include path - they're mutually exclusive in Playwright
                 if cf_clearance:
-                    desired_cookies.append({"name": "cf_clearance", "value": cf_clearance, "domain": ".lmarena.ai", "path": "/"})
+                    desired_cookies.append({"name": "cf_clearance", "value": cf_clearance, "domain": ".lmarena.ai"})
                 if cf_bm:
-                    desired_cookies.append({"name": "__cf_bm", "value": cf_bm, "domain": ".lmarena.ai", "path": "/"})
+                    desired_cookies.append({"name": "__cf_bm", "value": cf_bm, "domain": ".lmarena.ai"})
                 if cfuvid:
-                    desired_cookies.append({"name": "_cfuvid", "value": cfuvid, "domain": ".lmarena.ai", "path": "/"})
+                    desired_cookies.append({"name": "_cfuvid", "value": cfuvid, "domain": ".lmarena.ai"})
                 if provisional_user_id:
                     desired_cookies.append(
-                        {"name": "provisional_user_id", "value": provisional_user_id, "domain": ".lmarena.ai", "path": "/"}
+                        {"name": "provisional_user_id", "value": provisional_user_id, "domain": ".lmarena.ai"}
                     )
-
                 if desired_cookies:
                     try:
                         existing_names: set[str] = set()


### PR DESCRIPTION
## Summary

- Fixes Playwright/Camoufox cookie setting errors by removing invalid `path` attribute when `domain` is used
- This was causing errors like "Cookie should have either url or path" in browser contexts
- Related to issue #77 (401 unauthorized - arena-auth-prod-v1 does not exist)

## Changes

In Playwright/Camoufox, specifying both `domain` and `path` in cookie specs is invalid - they are mutually exclusive. This was causing the error:

```
Failed to set provisional_user_id cookies in browser context: Error: BrowserContext.add_cookies: Cookie should have either url or path
```

The fix removes the redundant `path` attribute from all cookie specs that use `domain`:

- `transport.py`: 4 locations (lines ~466, 633, 1120, 1854)
- `recaptcha.py`: 1 location (line ~446)

All affected cookies: `cf_clearance`, `__cf_bm`, `_cfuvid`, `provisional_user_id`, `_GRECAPTCHA`

## Testing

- Syntax validation passed for both files
- Imports verified working