### PR TITLE
fix(transport): restore auth_token handling独立性 from grecaptcha_cookie

### DIFF
--- a/src/transport.py
+++ b/src/transport.py
@@ -646,6 +646,7 @@ async def fetch_lmarena_stream_via_chrome(
         )
     if grecaptcha_cookie:
         desired_cookies.append({"name": "_GRECAPTCHA", "value": grecaptcha_cookie, "domain": ".lmarena.ai"})
+    if auth_token:
         desired_cookies.extend(_arena_auth_cookie_specs(auth_token))
 
     user_agent = _m().normalize_user_agent_value(config.get("user_agent"))


### PR DESCRIPTION
## Summary

Fixes a critical bug introduced in PR #105 where `auth_token` cookie handling was incorrectly placed inside the `grecaptcha_cookie` conditional block.

## Bug Description

The previous PR #105 accidentally placed the line:
```python
desired_cookies.extend(_arena_auth_cookie_specs(auth_token))
```

Inside the `if grecaptcha_cookie:` block, causing authentication cookies to **only** be added when a `grecaptcha_cookie` is also present. This breaks authentication when there's an `auth_token` but no `grecaptcha_cookie`.

## Fix

Move auth_token handling to its own independent conditional block:

```python
if grecaptcha_cookie:
    desired_cookies.append({"name": "_GRECAPTCHA", "value": grecaptcha_cookie, "domain": ".lmarena.ai"})
if auth_token:
    desired_cookies.extend(_arena_auth_cookie_specs(auth_token))
```

## Testing

- Syntax validation passed

Fixes #108