### PR TITLE
chore: sync cloudwaddie-agent.yml from actions-agent

### DIFF
--- a/.github/workflows/cloudwaddie-agent.yml
+++ b/.github/workflows/cloudwaddie-agent.yml
@@ -528,6 +528,11 @@ jobs:
           - Repository: REPO_PLACEHOLDER
           - Default Branch: BRANCH_PLACEHOLDER
 
+          ## IMPORTANT: Directory Awareness
+          - The `oh-my-opencode/` directory is part of the agent itself (from code-yeongyu/oh-my-opencode), NOT the project being worked on
+          - When exploring or modifying the project, IGNORE the `oh-my-opencode/` directory
+          - Focus only on the actual project files, not the agent's own tooling
+
           ## User's Request
           COMMENT_PLACEHOLDER
 


### PR DESCRIPTION
Automated sync of `cloudwaddie-agent.yml` from [CloudWaddie/actions-agent](https://github.com/CloudWaddie/actions-agent).

This PR was created automatically because the local copy differs from the source.