### PR TITLE
Add setup instructions and password hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,13 @@ To use the LM Arena Bridge, you need to get your authentication token from the L
 
 1.  Go to the admin portal.
 2.  Login.
-3.  Add the token to the list.
+### 2. Configure the Application
+
+1.  Run the bridge: `python src/main.py`
+2.  Open the admin portal at `http://localhost:8000/dashboard`
+3.  Login with the default password: `admin`
+4.  Add your `arena-auth-prod-v1` token to the list
+5.  (Optional) Change the admin password in the dashboard or `config.json`
 
 ### 3. Run the Application
 

--- a/src/main.py
+++ b/src/main.py
@@ -1176,6 +1176,24 @@ async def login_page(request: Request, error: Optional[str] = None):
                     border-radius: 6px;
                     margin-bottom: 20px;
                     border-left: 4px solid #c33;
+                .error-message {{
+                    background: #fee;
+                    color: #c33;
+                    padding: 12px;
+                    border-radius: 6px;
+                    margin-bottom: 20px;
+                    border-left: 4px solid #c33;
+                }}
+                .password-hint {{
+                    font-size: 12px;
+                    color: #888;
+                    margin-top: 8px;
+                }}
+                .password-hint code {{
+                    background: #f5f5f5;
+                    padding: 2px 6px;
+                    border-radius: 4px;
+                    font-family: monospace;
                 }}
             </style>
         </head>
@@ -1188,6 +1206,10 @@ async def login_page(request: Request, error: Optional[str] = None):
                     <div class="form-group">
                         <label for="password">Password</label>
                         <input type="password" id="password" name="password" placeholder="Enter your password" required autofocus>
+                    <div class="form-group">
+                        <label for="password">Password</label>
+                        <input type="password" id="password" name="password" placeholder="Enter your password" required autofocus>
+                        <div class="password-hint">Default password: <code>admin</code></div>
                     </div>
                     <button type="submit">Sign In</button>
                 </form>


### PR DESCRIPTION
## Summary

- Add default password hint (`admin`) displayed below password input on the login page
- Expand README setup instructions with explicit default password and clearer steps

## Changes

### Login Page (src/main.py)
- Added password hint below the password input field showing "Default password: admin"

### README (README.md)
- Expanded "Configure the Application" section with explicit steps:
  - Run the bridge command
  - Dashboard URL
  - Default password
  - How to add tokens
  - Optional password change

This resolves confusion reported in issue #81 where users didn't know the default login password.