### PR TITLE
fix: Resolve Permission denied to access object error in recaptcha

### DIFF
--- a/src/recaptcha.py
+++ b/src/recaptcha.py
@@ -682,10 +682,21 @@ async def get_recaptcha_v3_token() -> Optional[str]:
             # 4. TRIGGER: Execute reCAPTCHA and write to the variable
             # We do NOT await the result here. We just fire the process.
             _m().debug_print("  🚀 Triggering reCAPTCHA execution...")
+            # Firefox Xray wrapper blocks inline objects - use new w.Object() pattern
             trigger_script = f"""() => {{
                 const w = window.wrappedJSObject || window;
                 try {{
-                    w.grecaptcha.enterprise.execute('{recaptcha_sitekey}', {{ action: '{recaptcha_action}' }})
+                    // Pick the right grecaptcha (enterprise or regular)
+                    const ent = w?.grecaptcha?.enterprise;
+                    const g = (ent && typeof ent.execute === 'function') ? ent : w?.grecaptcha;
+                    if (!g || typeof g.execute !== 'function') {{
+                        w.__token_result = 'SYNC_ERROR: No valid grecaptcha found';
+                        return;
+                    }}
+                    // Firefox Xray wrappers: build params in the page compartment.
+                    const params = new w.Object();
+                    params.action = '{recaptcha_action}';
+                    g.execute('{recaptcha_sitekey}', params)
                     .then(token => {{
                         w.__token_result = token;
                     }})


### PR DESCRIPTION
## Summary

Fixes the recurring 503 Service Unavailable error caused by reCAPTCHA token refresh failing with `SYNC_ERROR: Error: Permission denied to access object`.

## Root Cause

Firefox's Xray wrapper blocks inline object literals when calling `grecaptcha.enterprise.execute()`. The previous code used:

```javascript
w.grecaptcha.enterprise.execute(sitekey, { action: '...' })
```

This inline object `{ action: '...' }` triggers a security error: "Permission denied to access object".

## Solution

Apply the same workaround used in `_mint_recaptcha_v3_token_in_page`:

1. Use `new w.Object()` to create params in the page compartment
2. Use `pickG()` pattern to select between enterprise and regular grecaptcha

## Changes

- `src/recaptcha.py`: Updated trigger_script to use `new w.Object()` pattern

## Testing

Users should test by:
1. Pulling this branch
2. Making an API request to trigger reCAPTCHA
3. Verify no "Permission denied to access object" error

Expected output after fix:
- ✅ Turnstile challenge resolved
- ✅ reCAPTCHA library loads properly
- ✅ Token captured successfully
- ✅ No more 503 errors