### PR TITLE
README: shrink AI Leaks logo and add FMHY feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 <a href="https://www.drips.network/app/projects/github/CloudWaddie/LMArenaBridge" target="_blank"><img src="https://www.drips.network/api/embed/project/https%3A%2F%2Fgithub.com%2FCloudWaddie%2FLMArenaBridge/support.png?background=light&style=drips&text=project&stat=support" alt="Support LMArenaBridge on drips.network" height="32"></a>
 
 ### Thank you to the [AI Leaks server](https://discord.gg/fqmaHkQpJZ) for being a partner!
-![AI-Leaks-Logo](https://github.com/user-attachments/assets/5fd3d456-152c-44e2-acee-f4c2a1ca2caa)
+<img width="200" alt="AI-Leaks-Logo" src="https://github.com/user-attachments/assets/5fd3d456-152c-44e2-acee-f4c2a1ca2caa">
+
+### As featured in [FMHY](https://fmhy.net/ai#multiple-model-sites)
 
 ### Check out my sister project [YuppBridge](https://github.com/cloudWaddie/yuppbridge) - A bridge to interact with Yupp Arena!
 


### PR DESCRIPTION
## Summary
- Shrink the AI Leaks logo image from full size to 200px width
- Add "As featured in FMHY" link pointing to https://fmhy.net/ai#multiple-model-sites