### PR TITLE
fix: use sign_up action for anonymous users in reCAPTCHA

### DIFF
--- a/src/recaptcha.py
+++ b/src/recaptcha.py
@@ -101,8 +101,19 @@ def get_recaptcha_settings(config: Optional[dict] = None) -> tuple[str, str]:
     action = str((cfg or {}).get("recaptcha_action") or "").strip()
     if not sitekey:
         sitekey = _m().RECAPTCHA_SITEKEY
+    
     if not action:
-        action = _m().RECAPTCHA_ACTION
+        auth_tokens = cfg.get("auth_tokens", []) if cfg else []
+        if isinstance(auth_tokens, list):
+            auth_tokens = [str(t or "").strip() for t in auth_tokens if str(t or "").strip()]
+        
+        has_valid_token = any(
+            _m().is_probably_valid_arena_auth_token(t) 
+            for t in auth_tokens
+        )
+        
+        action = "chat_submit" if has_valid_token else "sign_up"
+    
     return sitekey, action
 
 


### PR DESCRIPTION
## Summary

- Fix reCAPTCHA timeout for anonymous users by using correct action
- When no valid auth token is configured, use `sign_up` action instead of `chat_submit`

## Problem

The 503 errors were caused by reCAPTCHA token timeouts. The root cause:
1. Anonymous users (no valid auth token) need `sign_up` action for reCAPTCHA v3
2. The code was always using `chat_submit` regardless of auth token status
3. Google reCAPTCHA rejects the wrong action → Promise hangs → timeout

## Solution

Modified `get_recaptcha_settings()` to check for valid auth tokens:
- No valid auth token → use `sign_up` action  
- Has valid auth token → use `chat_submit` action

This ensures anonymous users get the correct reCAPTCHA action.

## Testing

- Manual verification: No auth tokens returns `sign_up`, valid token returns `chat_submit`
- Existing tests pass