### PR TITLE
Fix reCAPTCHA v3 token timeout

### DIFF
--- a/src/recaptcha.py
+++ b/src/recaptcha.py
@@ -693,12 +693,7 @@ async def get_recaptcha_v3_token() -> Optional[str]:
                     _m().debug_print("❌ reCAPTCHA library never loaded.")
                     return None
 
-            # 3. SETUP: Initialize our global result variable
-            # We use a unique name to avoid conflicts
-            await _m().safe_page_evaluate(page, "() => { (window.wrappedJSObject || window).__token_result = 'PENDING'; }")
-
-            # 4. TRIGGER: Execute reCAPTCHA and write to the variable
-            # We use async/await directly instead of .then() to ensure the Promise resolves
+            # 3. TRIGGER: Execute reCAPTCHA using async/await for reliable Promise resolution
             _m().debug_print("  🚀 Triggering reCAPTCHA execution...")
             # Firefox Xray wrapper blocks inline objects - use new w.Object() pattern
             trigger_script = f"""async () => {{
@@ -728,41 +723,13 @@ async def get_recaptcha_v3_token() -> Optional[str]:
                 _m().RECAPTCHA_EXPIRY = datetime.now(timezone.utc) + timedelta(seconds=110)
                 _m().debug_print(f"✅ Token captured! ({len(token)} chars)")
                 return token
-            elif token and token.startswith('SYNC_ERROR'):
-                _m().debug_print(f"❌ {token}")
             
-            # Fallback: if direct await failed, try the polling approach
-            if not token or token == 'PENDING':
-                _m().debug_print("  👀 Polling for result...")
-                token = None
-                
-                for i in range(20): # Wait up to 20 seconds
-                    # Read the global variable
-                    result = await _m().safe_page_evaluate(page, "() => (window.wrappedJSObject || window).__token_result", retries=2)
-                    
-                    if result != 'PENDING':
-                        if result and result.startswith('ERROR'):
-                            _m().debug_print(f"❌ JS Execution Error: {result}")
-                            return None
-                        elif result and result.startswith('SYNC_ERROR'):
-                            _m().debug_print(f"❌ JS Sync Error: {result}")
-                            return None
-                        else:
-                            token = result
-                            _m().debug_print(f"✅ Token captured! ({len(token)} chars)")
-                            break
-                    
-                    if i % 2 == 0:
-                        _m().debug_print(f"    ... waiting ({i}s)")
-                    await asyncio.sleep(1)
+            if token and token.startswith('SYNC_ERROR'):
+                _m().debug_print(f"❌ {token}")
+            else:
+                _m().debug_print("❌ Failed to get token via direct evaluate (timed out or other error).")
 
-                if token:
-                    _m().RECAPTCHA_TOKEN = token
-                    _m().RECAPTCHA_EXPIRY = datetime.now(timezone.utc) + timedelta(seconds=110)
-                    return token
-                else:
-                    _m().debug_print("❌ Timed out waiting for token variable to update.")
-                    return None
+            return None
 
     except Exception as e:
         _m().debug_print(f"❌ Unexpected error: {e}")


### PR DESCRIPTION
## Summary

- Fix reCAPTCHA v3 token timeout issue by using async/await directly instead of Promise .then() chain
- Add debug logging to see which sitekey and action are being used
- Add support for legacy  field (singular) in addition to  (list) for backward compatibility
- **Updated**: Remove broken polling fallback and dead code (addresses gemini code review comments)

## Root Cause

The reCAPTCHA token was timing out because the Promise callback in the trigger script wasn't being called in some cases. The original code used:

```javascript
g.execute(sitekey, params).then(token => {
    w.__token_result = token;
});
```

This approach relies on the `.then()` callback being executed, which wasn't happening reliably.

## Fix

Changed to use async/await directly:

```javascript
const token = await g.execute(sitekey, params);
return String(token || '');
```

This returns the token directly from the evaluate call, eliminating the need for the side-channel polling mechanism.

## Code Review Fixes (gemini)

- **Critical**: Removed broken polling fallback - the async script returns token directly, not via `__token_result` variable, so polling fallback would always timeout
- **High**: Already fixed in previous commit (str(cfg.get("auth_token") or ""))
- **Medium**: Removed dead code - `__token_result = 'PENDING'` initialization no longer needed

## Testing

- Existing tests pass (2 pre-existing failures unrelated to this change)
- Added debug logging to help diagnose any remaining issues