### PR TITLE
fix: resolve NameError for undefined use_chrome_fetch_for_model (closes #133)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -4283,7 +4283,7 @@ async def api_chat_completions(request: Request, api_key: dict = Depends(rate_li
                     debug_print("⚠️ Userscript Proxy returned None. Falling back...")
 
             if response is None:
-                if model_public_name in STRICT_BROWSER_FETCH_MODELS:
+                if strict_chrome_fetch_model:
                     debug_print(f"🌐 Using Chrome fetch transport for non-streaming strict model ({model_public_name})...")
                     # Chrome fetch transport has its own internal reCAPTCHA retries, 
                     # but we add an outer loop here to handle token rotation (401) and rate limits (429).


### PR DESCRIPTION
## Summary

- Fixes `NameError: name 'use_chrome_fetch_for_model' is not defined` when processing non-streaming chat completion requests
- The non-streaming code path referenced an undefined variable `use_chrome_fetch_for_model`
- Fixed by using the same logic as the streaming path: `model_public_name in STRICT_BROWSER_FETCH_MODELS`

## Change

```diff
-                if use_chrome_fetch_for_model:
+                if model_public_name in STRICT_BROWSER_FETCH_MODELS:
```

This matches the existing pattern used in the streaming code at line 2342.