### PR TITLE
fix: Dashboard shows 'Not Set' even when auth tokens are configured

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1320,9 +1320,10 @@ async def dashboard(session: str = Depends(get_current_session)):
     else:
         stats_html = "<tr><td colspan='2' class='no-data'>No usage data yet</td></tr>"
 
-    # Check token status
-    token_status = "✅ Configured" if config.get("auth_token") else "❌ Not Set"
-    token_class = "status-good" if config.get("auth_token") else "status-bad"
+    # Check token status - check both legacy auth_token and new auth_tokens list
+    has_auth_token = bool(config.get("auth_token")) or bool(config.get("auth_tokens"))
+    token_status = "✅ Configured" if has_auth_token else "❌ Not Set"
+    token_class = "status-good" if has_auth_token else "status-bad"
     
     cf_status = "✅ Configured" if config.get("cf_clearance") else "❌ Not Set"
     cf_class = "status-good" if config.get("cf_clearance") else "status-bad"


### PR DESCRIPTION
## Summary

Fixes #151 - The dashboard was displaying "❌ Not Set" for Arena Auth Token status even when tokens were properly configured.

## Problem

The dashboard only checked for the legacy `auth_token` field (single token), but users add tokens to the `auth_tokens` list (multiple tokens for round-robin). This caused the status to show "❌ Not Set" even when valid tokens were configured.

## Solution

- Modified the token status check to look at both `config["auth_token"]` (legacy single token) and `config["auth_tokens"]` (token list)
- Shows "✅ Configured" if either field has a valid token

## Changes

- Updated `dashboard()` function in `src/main.py`
- Changed token status check from `config.get("auth_token")` to `bool(config.get("auth_token")) or bool(config.get("auth_tokens"))`

## Testing

- Syntax verified: `python3 -c "import ast; ast.parse(open('src/main.py').read()); print('OK')"`

Closes #151