### PR TITLE
fix: Use _cs alias for cloudscraper exceptions to fix NameError

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -526,7 +526,7 @@ async def refresh_arena_auth_token_via_lmarena_http(old_token: str, config: Opti
             return scraper.get("https://lmarena.ai/", cookies=cookies, timeout=30, allow_redirects=True)
         import asyncio as _aio
         resp = await _aio.to_thread(_cs_get)
-    except (cloudscraper.exceptions.CloudflareException, requests.exceptions.RequestException):
+    except (_cs.exceptions.CloudflareException, requests.exceptions.RequestException):
         return None
 
     try:

--- a/src/main.py
+++ b/src/main.py
@@ -2642,7 +2642,7 @@ async def api_chat_completions(request: Request, api_key: dict = Depends(rate_li
                     response.raise_for_status()
                     return response
 
-                except (requests.exceptions.HTTPError, cloudscraper.exceptions.CloudflareException) as e:
+                except (requests.exceptions.HTTPError, _cs.exceptions.CloudflareException) as e:
                     # Handle HTTP errors from cloudscraper (requests-based)
                     status_code = getattr(getattr(e, 'response', None), 'status_code', None)
                     if status_code and status_code not in [429, 401]:


### PR DESCRIPTION
Fixed 'NameError: name cloudscraper is not defined' by using the already imported _cs alias instead of the cloudscraper module name.

Changes:
- src/main.py: Changed cloudscraper.exceptions to _cs.exceptions
- src/auth.py: Changed cloudscraper.exceptions to _cs.exceptions

This fixes the error reported in issue #148 where cloudscraper was referenced directly instead of via the _cs alias.

Fixes #148