### PR TITLE
Add Ollama-compatible stub endpoints for OpenWebUI

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1336,7 +1336,7 @@ async def dashboard(session: str = Depends(get_current_session)):
         stats_html = "<tr><td colspan='2' class='no-data'>No usage data yet</td></tr>"
 
     # Check token status - check both legacy auth_token and new auth_tokens list
-                has_auth_token = bool(str(config.get("auth_token") or "").strip()) or any(config.get("auth_tokens") or [])
+    has_auth_token = bool(str(config.get("auth_token") or "").strip()) or any(config.get("auth_tokens") or [])
     token_status = "✅ Configured" if has_auth_token else "❌ Not Set"
     token_class = "status-good" if has_auth_token else "status-bad"
     
@@ -2170,6 +2170,39 @@ async def health_check():
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "error": str(e)
         }
+
+# --- Ollama-compatible stubs (OpenWebUI probes these endpoints) ---
+
+@app.get("/api/v1/api/tags")
+async def ollama_tags(api_key: dict = Depends(rate_limit_api_key)):
+    models = get_models()
+    
+    valid_models = [m for m in models 
+                   if (m.get('capabilities', {}).get('outputCapabilities', {}).get('text')
+                       or m.get('capabilities', {}).get('outputCapabilities', {}).get('search')
+                       or m.get('capabilities', {}).get('outputCapabilities', {}).get('image'))
+                   and m.get('organization')]
+    
+    ollama_models = [
+        {
+            "name": model.get("publicName", ""),
+            "model": model.get("publicName", ""),
+            "modified_at": "2024-01-01T00:00:00Z",
+            "size": 0
+        }
+        for model in valid_models if model.get("publicName")
+    ]
+    return {"models": ollama_models}
+
+
+@app.get("/api/v1/api/ps")
+async def ollama_ps(api_key: dict = Depends(rate_limit_api_key)):
+    return {"models": []}
+
+
+@app.get("/api/v1/api/version")
+async def ollama_version(api_key: dict = Depends(rate_limit_api_key)):
+    return {"version": "0.1.0"}
 
 @app.get("/api/v1/models")
 async def list_models(api_key: dict = Depends(rate_limit_api_key)):

--- a/src/main.py
+++ b/src/main.py
@@ -1320,9 +1320,10 @@ async def dashboard(session: str = Depends(get_current_session)):
     else:
         stats_html = "<tr><td colspan='2' class='no-data'>No usage data yet</td></tr>"
 
-    # Check token status
-    token_status = "✅ Configured" if config.get("auth_token") else "❌ Not Set"
-    token_class = "status-good" if config.get("auth_token") else "status-bad"
+    # Check token status - check both legacy auth_token and new auth_tokens list
+    has_auth_token = bool(config.get("auth_token")) or bool(config.get("auth_tokens"))
+    token_status = "✅ Configured" if has_auth_token else "❌ Not Set"
+    token_class = "status-good" if has_auth_token else "status-bad"
     
     cf_status = "✅ Configured" if config.get("cf_clearance") else "❌ Not Set"
     cf_class = "status-good" if config.get("cf_clearance") else "status-bad"


### PR DESCRIPTION
## Summary

- **Fixes #161** — OpenWebUI's Ollama integration probes `/api/v1/api/tags`, `/api/v1/api/ps`, and `/api/v1/api/version` endpoints which previously returned 404

## Changes

### `src/main.py`
- **`GET /api/v1/api/tags`** — Returns available models in Ollama format (`{models: [{name, model, modified_at, size}]}`)
- **`GET /api/v1/api/ps`** — Returns empty running models list (`{models: []}`)
- **`GET /api/v1/api/version`** — Returns version info (`{version: "0.1.0"}`)
- **Fixed pre-existing `IndentationError`** in `dashboard()` from merge conflict (16-space → 4-space indent)

## Notes

The issue owner commented that these 404s "can safely be ignored", but adding proper stubs eliminates log noise and prevents OpenWebUI's Ollama client from showing connection errors. The `/api/v1/api/tags` endpoint returns actual model data so OpenWebUI can list available models via its Ollama integration.