### PR TITLE
Fix Anthropic SSE buffering and error handling

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1336,7 +1336,7 @@ async def dashboard(session: str = Depends(get_current_session)):
         stats_html = "<tr><td colspan='2' class='no-data'>No usage data yet</td></tr>"
 
     # Check token status - check both legacy auth_token and new auth_tokens list
-                has_auth_token = bool(str(config.get("auth_token") or "").strip()) or any(config.get("auth_tokens") or [])
+    has_auth_token = bool(str(config.get("auth_token") or "").strip()) or any(config.get("auth_tokens") or [])
     token_status = "✅ Configured" if has_auth_token else "❌ Not Set"
     token_class = "status-good" if has_auth_token else "status-bad"
     
@@ -4786,7 +4786,8 @@ async def anthropic_messages(request: AnthropicMessageRequest, raw_request: Requ
         async def anthropic_stream_generator():
             message_id = f"msg_{uuid.uuid4()}"
             accumulated_text = ""
-
+            buffer = ""
+            
             # Send message_start
             yield f"event: message_start\ndata: {json.dumps({'type': 'message_start', 'message': {'id': message_id, 'type': 'message', 'role': 'assistant', 'content': [], 'model': request.model, 'stop_reason': None, 'usage': {'input_tokens': sum(len(str(m.get('content', ''))) for m in openai_messages), 'output_tokens': 0}}})}\n\n"
 
@@ -4796,23 +4797,35 @@ async def anthropic_messages(request: AnthropicMessageRequest, raw_request: Requ
             try:
                 result = await api_chat_completions(mock_request, api_key)
 
+                # Return error for dict response (error case)
+                if isinstance(result, dict) and result.get("error"):
+                    yield f"event: error\ndata: {json.dumps({'type': 'error', 'error': {'message': result['error'].get('message', 'Unknown error'), 'type': result['error'].get('type', 'invalid_request_error')}})}\n\n"
+                    return
+                
                 if isinstance(result, StreamingResponse):
                     async for chunk in result.body_iterator:
                         chunk_str = chunk.decode('utf-8') if isinstance(chunk, bytes) else str(chunk)
-                        for line in chunk_str.strip().split('\n'):
-                            if line.startswith('data: '):
-                                data = line[6:]
-                                if data == '[DONE]':
-                                    break
-                                try:
-                                    chunk_data = json.loads(data)
-                                    delta = chunk_data.get("choices", [{}])[0].get("delta", {})
-                                    if "content" in delta:
-                                        content = delta["content"]
-                                        accumulated_text += content
-                                        yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': 0, 'delta': {'type': 'text_delta', 'text': content}})}\n\n"
-                                except json.JSONDecodeError:
-                                    continue
+                        buffer += chunk_str
+                        while '\n' in buffer:
+                            line, buffer = buffer.split('\n', 1)
+                            line = line.strip()
+                            if not line.startswith('data: '):
+                                continue
+                            data = line[6:]
+                            if data == '[DONE]':
+                                break
+                            try:
+                                chunk_data = json.loads(data)
+                                delta = chunk_data.get("choices", [{}])[0].get("delta", {})
+                                if "content" in delta:
+                                    content = delta["content"]
+                                    accumulated_text += content
+                                    yield f"event: content_block_delta\ndata: {json.dumps({'type': 'content_block_delta', 'index': 0, 'delta': {'type': 'text_delta', 'text': content}})}\n\n"
+                            except json.JSONDecodeError:
+                                continue
+                else:
+                    yield f"event: error\ndata: {json.dumps({'type': 'error', 'error': {'message': 'Unexpected non-streaming response from API', 'type': 'internal_error'}})}\n\n"
+                    return
 
             except Exception as e:
                 yield f"event: error\ndata: {json.dumps({'type': 'error', 'error': {'message': str(e), 'type': 'internal_error'}})}\n\n"


### PR DESCRIPTION
## Summary

This PR integrates the key fixes from PR #156 while addressing all review comments.

## Changes

- **Add buffer for SSE chunk accumulation** (Critical fix from PR #156)
  - SSE chunks from `body_iterator` are not guaranteed to be line-aligned
  - Buffer before parsing prevents JSONDecodeError on split payloads
- **Handle dict error responses** from `api_chat_completions`
  - Returns proper `error` event instead of ignoring
- **Handle unexpected non-streaming responses**
  - Returns error event instead of silent failure

## What was NOT integrated from PR #156

1. **Token status simplification** — Rejected by PR review, we keep checking both `auth_token` and `auth_tokens` (already fixed in PR #169)
2. **Hardcoded input_tokens=0** — Kept character count estimate (per review)
3. **word-split output_tokens** — Kept character count (per review)

## Recommendation

**Close PR #156** — The creator hasn't responded to review comments. This PR (#171) addresses all the valid fixes while rejecting the problematic changes.

## Testing

All tests pass (35 passed, 1 skipped)