### PR TITLE
fix: attempt token refresh on 401 before failing with Max retries exceeded

### DIFF
--- a/models.json
+++ b/models.json
@@ -1,0 +1,13060 @@
+[
+  {
+    "id": "019b24bb-5caf-71c3-b854-37d0c7086f21",
+    "organization": "boss-bandit",
+    "provider": "boss-bandit",
+    "publicName": "Max",
+    "name": "boss-bandit",
+    "displayName": "Max",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true,
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        },
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991,
+      "image": 9007199254740991,
+      "search": 9007199254740991
+    }
+  },
+  {
+    "id": "019c2f86-74db-7cc3-baa5-6891bebb5999",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropicAdaptive",
+    "publicName": "claude-opus-4-6-thinking",
+    "name": "claude-opus-4-6-thinking",
+    "displayName": "claude-opus-4-6-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 1,
+    "rankByModality": {
+      "chat": 1,
+      "webdev": 4
+    }
+  },
+  {
+    "id": "019d9808-2b2f-7272-b7ea-0634461e5316",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropicAdaptive",
+    "publicName": "claude-opus-4-7-thinking",
+    "name": "claude-opus-4-7-thinking",
+    "displayName": "claude-opus-4-7-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 2,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019c2fac-13de-7550-a751-f5f593c77c72",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropic",
+    "publicName": "claude-opus-4-6",
+    "name": "claude-opus-4-6-vertex",
+    "displayName": "claude-opus-4-6",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 3,
+    "rankByModality": {
+      "chat": 2,
+      "webdev": 4
+    }
+  },
+  {
+    "id": "019d9806-5d91-76b3-b353-826cb3193b43",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropic",
+    "publicName": "claude-opus-4-7",
+    "name": "claude-opus-4-7-vertex",
+    "displayName": "claude-opus-4-7",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 4,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d704a-f8ac-7927-983c-b033d10ef56f",
+    "organization": "meta",
+    "provider": "metaOpenAI",
+    "publicName": "eureka",
+    "name": "eureka",
+    "displayName": "muse-spark",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 5,
+    "rankByModality": {
+      "chat": 11
+    }
+  },
+  {
+    "id": "019e080d-c29d-7d9a-aa54-faed41da0763",
+    "organization": "google",
+    "publicName": "gemini-3.1-pro-preview",
+    "displayName": "gemini-3.1-pro-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 6,
+    "rankByModality": {
+      "chat": 13,
+      "webdev": 19
+    }
+  },
+  {
+    "id": "019cc544-4848-771d-947a-1121fad1acb4",
+    "publicName": "gemini-3.1-pro",
+    "displayName": "gemini-3.1-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 6,
+    "rankByModality": {
+      "chat": 13
+    }
+  },
+  {
+    "id": "019c7820-5480-78b6-9fef-04c0d7004054",
+    "organization": "google",
+    "provider": "googleVertexGlobal",
+    "publicName": "gemini-3.1-pro-preview",
+    "name": "gemini-3.1-pro-preview",
+    "displayName": "gemini-3.1-pro-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 6,
+    "rankByModality": {
+      "chat": 13,
+      "webdev": 19
+    }
+  },
+  {
+    "id": "019e1d78-5d58-79ea-8801-1bed09799b11",
+    "organization": "google",
+    "publicName": "gemini-3.1-pro-preview",
+    "displayName": "gemini-3.1-pro-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 6,
+    "rankByModality": {
+      "chat": 13,
+      "webdev": 19
+    }
+  },
+  {
+    "id": "019df477-8246-789c-bbdf-054a5f712ce3",
+    "organization": "google",
+    "publicName": "gemini-3.1-pro-preview",
+    "displayName": "gemini-3.1-pro-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 6,
+    "rankByModality": {
+      "chat": 13,
+      "webdev": 19
+    }
+  },
+  {
+    "id": "019e1d78-1883-7609-9b3d-2a265c1b5e8c",
+    "organization": "google",
+    "publicName": "gemini-3-pro",
+    "displayName": "gemini-3-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 7,
+    "rankByModality": {
+      "chat": 14,
+      "webdev": 22
+    }
+  },
+  {
+    "id": "019df477-3d05-7d5d-8852-b4cd85452379",
+    "organization": "google",
+    "publicName": "gemini-3-pro",
+    "displayName": "gemini-3-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 7,
+    "rankByModality": {
+      "chat": 14,
+      "webdev": 22
+    }
+  },
+  {
+    "id": "019cc5aa-2338-72fd-97dd-853736085a83",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.4-high-no-system-prompt",
+    "name": "gpt-5.4-high-no-system-prompt",
+    "displayName": "gpt-5.4-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 10,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c5826-23b2-7ea7-be9a-b4557462fe19",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-5.2-chat-latest",
+    "name": "gpt-5.2-chat-latest",
+    "displayName": "gpt-5.2-chat-latest",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 13,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ce35a-fa6f-7262-8ee2-ed4442821ce7",
+    "organization": "xai",
+    "provider": "xaiApi",
+    "publicName": "grok-4.20-beta-0309-reasoning",
+    "name": "grok-4.20-beta-0309-reasoning",
+    "displayName": "grok-4.20-beta-0309-reasoning",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 15,
+    "rankByModality": {
+      "chat": 19
+    }
+  },
+  {
+    "id": "019ceb00-ae9a-7aa3-98d8-25713be55d80",
+    "organization": "xai",
+    "provider": "xaiMultiAgent",
+    "publicName": "grok-4.20-multi-agent-beta-0309",
+    "name": "grok-4.20-multi-agent-beta-0309",
+    "displayName": "grok-4.20-multi-agent-beta-0309",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 16,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019b47da-49b9-7295-906c-ce44ccd30d74",
+    "organization": "google",
+    "provider": "googleVertexGlobal",
+    "publicName": "gemini-3-flash",
+    "name": "gemini-3-flash",
+    "displayName": "gemini-3-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 17,
+    "rankByModality": {
+      "chat": 20,
+      "webdev": 25
+    }
+  },
+  {
+    "id": "019df477-1160-7548-8d04-93bb58ff0502",
+    "organization": "google",
+    "publicName": "gemini-3-flash",
+    "displayName": "gemini-3-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 17,
+    "rankByModality": {
+      "chat": 20,
+      "webdev": 25
+    }
+  },
+  {
+    "id": "019d9d7d-3779-711c-8ee5-3887db632d75",
+    "organization": "baidu",
+    "provider": "baiduyiyan",
+    "publicName": "ernie-5.1-preview",
+    "name": "zero-prism",
+    "displayName": "ernie-5.1-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 18,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ab8b2-9bcf-79b5-9fb5-149a7c67b7c0",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropic",
+    "publicName": "claude-opus-4-5-20251101-thinking-32k",
+    "name": "claude-opus-4-5-20251101-thinking-32k",
+    "displayName": "claude-opus-4-5-20251101-thinking-32k",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 19,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 12
+    }
+  },
+  {
+    "id": "019df99c-e564-7a80-81e3-8a130fa9ef72",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.5-instant",
+    "name": "gpt-5.5-instant",
+    "displayName": "gpt-5.5-instant",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 21,
+    "rankByModality": {
+      "chat": 23
+    }
+  },
+  {
+    "id": "019c6d29-a30c-7e20-9bd0-6650af926623",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropic",
+    "publicName": "claude-sonnet-4-6",
+    "name": "claude-sonnet-4-6-vertex",
+    "displayName": "claude-sonnet-4-6",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 22,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 6
+    }
+  },
+  {
+    "id": "019adbec-8396-71cc-87d5-b47f8431a6a6",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropic",
+    "publicName": "claude-opus-4-5-20251101",
+    "name": "claude-opus-4-5-20251101-vertex",
+    "displayName": "claude-opus-4-5-20251101",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 23,
+    "rankByModality": {
+      "chat": 9,
+      "webdev": 15
+    }
+  },
+  {
+    "id": "019cfd71-33d0-7fb1-96f3-16780c95966d",
+    "publicName": "gpt-5.4-no-system-prompt",
+    "displayName": "gpt-5.4-no-system-prompt",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 24,
+    "rankByModality": {
+      "chat": 8
+    }
+  },
+  {
+    "id": "019cc5a9-cc73-721a-a124-efee4e783d1a",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.4-no-system-prompt",
+    "name": "gpt-5.4-no-system-prompt",
+    "displayName": "gpt-5.4",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 24,
+    "rankByModality": {
+      "chat": 8
+    }
+  },
+  {
+    "id": "019a9389-a9d3-77a8-afbb-4fe4dd3d8630",
+    "organization": "xai",
+    "provider": "xaiApi",
+    "publicName": "grok-4.1-thinking",
+    "name": "grok-4.1-thinking",
+    "displayName": "grok-4.1-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 25,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 73
+    }
+  },
+  {
+    "id": "019cddbe-a52e-720f-9398-0f40a2914b99",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "kiteki",
+    "name": "kiteki",
+    "displayName": "qwen3.5-max-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 27,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a9389-a4d8-748d-9939-b4640198302e",
+    "organization": "xai",
+    "provider": "xaiApi",
+    "publicName": "grok-4.1",
+    "name": "grok-4.1",
+    "displayName": "grok-4.1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 31,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019daede-d9ea-74fd-b121-853740b8f2a0",
+    "publicName": "kizen-beta",
+    "displayName": "kizen-beta",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 33,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c45d7-96f0-7d39-8143-9d57941b5523",
+    "organization": "zai",
+    "provider": "siliconFlowToolCalling",
+    "publicName": "glm-5",
+    "name": "glm-5",
+    "displayName": "glm-5",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 34,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d2ac4-285d-7765-8296-d9a3aa2f2662",
+    "publicName": "dola-seed-2.0-pro-text",
+    "displayName": "dola-seed-2.0-pro-text",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 35,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a8548-a2b1-70ce-b1be-eba096d41f58",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-5.1-high",
+    "name": "gpt-5.1-high",
+    "displayName": "gpt-5.1-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 36,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "b0ea1407-2f92-4515-b9cc-b22a6d6c14f2",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropic",
+    "publicName": "claude-sonnet-4-5-20250929-thinking-32k",
+    "name": "claude-sonnet-4-5-20250929-thinking-32k",
+    "displayName": "claude-sonnet-4-5-20250929-thinking-32k",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 37,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 40
+    }
+  },
+  {
+    "id": "019a2d13-28a5-7205-908c-0a58de904617",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropic",
+    "publicName": "claude-sonnet-4-5-20250929",
+    "name": "claude-sonnet-4-5-20250929",
+    "displayName": "claude-sonnet-4-5-20250929",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 38,
+    "rankByModality": {
+      "chat": 12,
+      "webdev": 42
+    }
+  },
+  {
+    "id": "019cfcdd-5426-777e-8314-04619cb92cc4",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.4-mini-high",
+    "name": "gpt-5.4-mini-high",
+    "displayName": "gpt-5.4-mini-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 39,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019b47ea-4256-7afd-85e6-8c0c8ea24a26",
+    "organization": "baidu",
+    "provider": "baiduyiyan",
+    "publicName": "ernie-5.0-0110",
+    "name": "proto-think",
+    "displayName": "ernie-5.0-0110",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 42,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cb505-30fa-7045-b4fb-94e57a63b2fa",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-5.3-chat-latest",
+    "name": "gpt-5.3-chat-latest",
+    "displayName": "gpt-5.3-chat-latest",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 45,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "f1a2eb6f-fc30-4806-9e00-1efd0d73cbc4",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropic",
+    "publicName": "claude-opus-4-1-20250805-thinking-16k",
+    "name": "claude-opus-4-1-20250805-thinking-16k",
+    "displayName": "claude-opus-4-1-20250805-thinking-16k",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 46,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d049f-233c-7694-989e-9545f9748354",
+    "organization": "xiaomi",
+    "provider": "xiaomiV1",
+    "publicName": "mimo-v2-pro",
+    "name": "mimo-v2-pro",
+    "displayName": "mimo-v2-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 47,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 27
+    }
+  },
+  {
+    "id": "96ae95fd-b70d-49c3-91cc-b58c7da1090b",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropic",
+    "publicName": "claude-opus-4-1-20250805",
+    "name": "claude-opus-4-1-20250805",
+    "displayName": "claude-opus-4-1-20250805",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 48,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 43
+    }
+  },
+  {
+    "id": "51a47cc6-5ef9-4ac7-a59c-4009230d7564",
+    "publicName": "gemini-2.5-pro-grounding-exp",
+    "displayName": "gemini-2.5-pro-grounding-exp",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 49,
+    "rankByModality": {
+      "chat": 16
+    }
+  },
+  {
+    "id": "0199f060-b306-7e1f-aeae-0ebb4e3f1122",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "gemini-2.5-pro",
+    "name": "gemini-2.5-pro",
+    "displayName": "gemini-2.5-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 49,
+    "rankByModality": {
+      "chat": 16,
+      "webdev": 74
+    }
+  },
+  {
+    "id": "019becd0-af81-7883-a7ca-5c4a4e42ff7a",
+    "organization": "zai",
+    "provider": "fireworks",
+    "publicName": "glm-4.7",
+    "name": "glm-4.7-text-fireworks",
+    "displayName": "glm-4.7",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 54,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019b1449-0313-7911-b836-419e2ed79b2e",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-5.2-high",
+    "name": "gpt-5.2-high-no-system-prompt-text",
+    "displayName": "gpt-5.2-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 56,
+    "rankByModality": {
+      "chat": 21
+    }
+  },
+  {
+    "id": "019a7ebf-0f3f-7518-8899-fca13e32d9dc",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-5.1",
+    "name": "gpt-5.1",
+    "displayName": "gpt-5.1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 57,
+    "rankByModality": {
+      "chat": 24,
+      "webdev": 54
+    }
+  },
+  {
+    "id": "019cb616-bf47-7457-acaf-3e2a15a882ef",
+    "organization": "google",
+    "provider": "googleVertexGlobalWithThoughtSignatures",
+    "publicName": "gemini-3.1-flash-lite-preview",
+    "name": "gemini-3.1-flash-lite-preview",
+    "displayName": "gemini-3.1-flash-lite-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 59,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 68
+    }
+  },
+  {
+    "id": "019cc543-573d-7a3f-b155-ad9cc5733aa6",
+    "publicName": "gpt-5.2",
+    "displayName": "gpt-5.2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 60,
+    "rankByModality": {
+      "chat": 22
+    }
+  },
+  {
+    "id": "019b1448-ff14-7c98-a1ac-726fece799ec",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-5.2",
+    "name": "gpt-5.2-no-system-prompt-text",
+    "displayName": "gpt-5.2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 60,
+    "rankByModality": {
+      "chat": 22
+    }
+  },
+  {
+    "id": "019ce48d-4a2c-7173-a667-7f05ce5402cb",
+    "organization": "meituan",
+    "provider": "meituanSankuai",
+    "publicName": "frieza",
+    "name": "frieza",
+    "displayName": "longcat-flash-chat-2602-exp",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 61,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019b9784-470e-75b9-b2fb-f005d78972e1",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-max-preview",
+    "name": "qwen3-max-preview-v2",
+    "displayName": "qwen3-max-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 62,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "983bc566-b783-4d28-b24c-3c8b08eb1086",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-5-high",
+    "name": "gpt-5-high",
+    "displayName": "gpt-5-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 63,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cb680-bae8-70e8-aacd-31f21dce7461",
+    "organization": "moonshot",
+    "provider": "moonshot",
+    "publicName": "kimi-k2.5-instant",
+    "name": "kimi-k2.5-instant-20260302",
+    "displayName": "kimi-k2.5-instant",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 65,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "cb0f1e24-e8e9-4745-aabc-b926ffde7475",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "o3-2025-04-16",
+    "name": "o3-2025-04-16",
+    "displayName": "o3-2025-04-16",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 67,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a59bc-8bb8-7933-92eb-fe143770c211",
+    "organization": "moonshot",
+    "provider": "moonshot",
+    "publicName": "kimi-k2-thinking-turbo",
+    "name": "kimi-k2-thinking-turbo",
+    "displayName": "kimi-k2-thinking-turbo",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 68,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 58
+    }
+  },
+  {
+    "id": "4b11c78c-08c8-461c-938e-5fc97d56a40d",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-5-chat",
+    "name": "gpt-5-chat",
+    "displayName": "gpt-5-chat",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 71,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "98ad8b8b-12cd-46cd-98de-99edde7e03eb",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-max-2025-09-23",
+    "name": "qwen3-max-2025-09-23",
+    "displayName": "qwen3-max-2025-09-23",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 74,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "3b5e9593-3dc0-4492-a3da-19784c4bde75",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropic",
+    "publicName": "claude-opus-4-20250514-thinking-16k",
+    "name": "claude-opus-4-20250514-thinking-16k",
+    "displayName": "claude-opus-4-20250514-thinking-16k",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 75,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "ee7cb86e-8601-4585-b1d0-7c7380f8f6f4",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-235b-a22b-instruct-2507",
+    "name": "qwen3-235b-a22b-instruct-2507",
+    "displayName": "qwen3-235b-a22b-instruct-2507",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 77,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "71023e9b-7361-498a-b6db-f2d2a83883fd",
+    "organization": "xai",
+    "provider": "xaiResearch",
+    "publicName": "grok-4-fast-chat",
+    "name": "grok-4-fast",
+    "displayName": "grok-4-fast-chat",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 81,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "b88e983b-9459-473d-8bf1-753932f1679a",
+    "organization": "moonshot",
+    "provider": "moonshot",
+    "publicName": "kimi-k2-0905-preview",
+    "name": "kimi-k2-0905-preview",
+    "displayName": "kimi-k2-0905-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 83,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c9270-083e-72b7-9bb6-ef32fe092f51",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3.5-122b-a10b",
+    "name": "qwen3.5-122b-a10b",
+    "displayName": "qwen3.5-122b-a10b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 85,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "7a3626fc-4e64-4c9e-821f-b449a4b43b6a",
+    "organization": "moonshot",
+    "provider": "moonshot",
+    "publicName": "kimi-k2-0711-preview",
+    "name": "kimi-k2-0711-preview",
+    "displayName": "kimi-k2-0711-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 88,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "716aa8ca-d729-427f-93ab-9579e4a13e98",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-vl-235b-a22b-instruct",
+    "name": "qwen3-vl-235b-a22b-instruct",
+    "displayName": "qwen3-vl-235b-a22b-instruct",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 92,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019acbac-df7c-73dc-9716-ebe040daaa4e",
+    "organization": "mistral",
+    "provider": "mistral",
+    "publicName": "mistral-large-3",
+    "name": "jaguar",
+    "displayName": "mistral-large-3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 93,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 72
+    }
+  },
+  {
+    "id": "14e9311c-94d2-40c2-8c54-273947e208b0",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-4.1-2025-04-14",
+    "name": "gpt-4.1-2025-04-14",
+    "displayName": "gpt-4.1-2025-04-14",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 94,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "ee116d12-64d6-48a8-88e5-b2d06325cdd2",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropic",
+    "publicName": "claude-opus-4-20250514",
+    "name": "claude-opus-4-20250514",
+    "displayName": "claude-opus-4-20250514",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 95,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "0199f059-3877-7cfe-bc80-e01b1a4a83de",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "gemini-2.5-flash",
+    "name": "gemini-2.5-flash",
+    "displayName": "gemini-2.5-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 98,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "0199e8e9-01ed-73e0-96ba-cf43b286bf10",
+    "organization": "anthropic",
+    "provider": "anthropic",
+    "publicName": "claude-haiku-4-5-20251001",
+    "name": "claude-haiku-4-5-20251001",
+    "displayName": "claude-haiku-4-5-20251001",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 99,
+    "rankByModality": {
+      "chat": 18,
+      "webdev": 60
+    }
+  },
+  {
+    "id": "27035fb8-a25b-4ec9-8410-34be18328afd",
+    "organization": "mistral",
+    "provider": "mistral",
+    "publicName": "mistral-medium-2508",
+    "name": "mistral-medium-2508",
+    "displayName": "mistral-medium-2508",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 101,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cf4e3-36a5-75a8-811d-1eaf867e3d0d",
+    "organization": "minimax",
+    "provider": "minimaxAnthropic",
+    "publicName": "deep-octo",
+    "name": "deep-octo",
+    "displayName": "minimax-m2.7",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 102,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 31
+    }
+  },
+  {
+    "id": "019c9240-6a0f-704e-954a-0d1e3b1b660c",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3.5-27b",
+    "name": "qwen3.5-27b",
+    "displayName": "qwen3.5-27b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 103,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cfcdd-0bca-706f-92b5-a4c4cbd022d8",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.4-nano-high",
+    "name": "gpt-5.4-nano-high",
+    "displayName": "gpt-5.4-nano-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 104,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "1a400d9a-f61c-4bc2-89b4-a9b7e77dff12",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-235b-a22b-no-thinking",
+    "name": "qwen3-235b-a22b-no-thinking",
+    "displayName": "qwen3-235b-a22b-no-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 107,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "351fe482-eb6c-4536-857b-909e16c0bf52",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-next-80b-a3b-instruct",
+    "name": "qwen3-next-80b-a3b-instruct",
+    "displayName": "qwen3-next-80b-a3b-instruct",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 108,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "6fcbe051-f521-4dc7-8986-c429eb6191bf",
+    "organization": "meituan",
+    "provider": "meituan",
+    "publicName": "longcat-flash-chat",
+    "name": "longcat-flash-chat",
+    "displayName": "longcat-flash-chat",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 110,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "16b8e53a-cc7b-4608-a29a-20d4dac77cf2",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-235b-a22b-thinking-2507",
+    "name": "qwen3-235b-a22b-thinking-2507",
+    "displayName": "qwen3-235b-a22b-thinking-2507",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 111,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "4653dded-a46b-442a-a8fe-9bb9730e2453",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropic",
+    "publicName": "claude-sonnet-4-20250514-thinking-32k",
+    "name": "claude-sonnet-4-20250514-thinking-32k",
+    "displayName": "claude-sonnet-4-20250514-thinking-32k",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 112,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c9254-5c32-70d0-8877-afdfd3590e1d",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3.5-35b-a3b",
+    "name": "qwen3.5-35b-a3b",
+    "displayName": "qwen3.5-35b-a3b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 114,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "6a3a1e04-050e-4cb4-9052-b9ac4bec0c38",
+    "organization": "tencent",
+    "provider": "tencent",
+    "publicName": "hunyuan-vision-1.5-thinking",
+    "name": "hunyuan-vision-1.5-thinking",
+    "displayName": "hunyuan-vision-1.5-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 115,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c9aff-e04b-746b-82bd-9c771362bcd9",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3.5-flash",
+    "name": "qwen3.5-flash",
+    "displayName": "qwen3.5-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 116,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 70
+    }
+  },
+  {
+    "id": "03c511f5-0d35-4751-aae6-24f918b0d49e",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-vl-235b-a22b-thinking",
+    "name": "qwen3-vl-235b-a22b-thinking",
+    "displayName": "qwen3-vl-235b-a22b-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 117,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d22bb-fcf5-7866-9c07-de74fe05c9cc",
+    "organization": "stepfun",
+    "provider": "openrouter",
+    "publicName": "step-3.5-flash",
+    "name": "step-3.5-flash-openrouter",
+    "displayName": "step-3.5-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 119,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c52a8-650a-7a55-b321-7fbc1c56588b",
+    "organization": "minimax",
+    "provider": "minimaxAnthropic",
+    "publicName": "minimax-m2.5",
+    "name": "minimax-m2.5",
+    "displayName": "minimax-m2.5",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 121,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 45
+    }
+  },
+  {
+    "id": "019ade1a-a918-79dd-9ef9-ba22f97c977d",
+    "publicName": "micro-mango",
+    "displayName": "micro-mango",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 122,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019bc5e5-b128-70da-a943-a7eb0b4aa656",
+    "organization": "xiaomi",
+    "provider": "xiaomiV1",
+    "publicName": "mimo-v2-flash (thinking)",
+    "name": "mimo-v2-flash-thinking-v2",
+    "displayName": "mimo-v2-flash (thinking)",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 122,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 55
+    }
+  },
+  {
+    "id": "019b352d-36a8-7dd3-bbec-2bc78852d6c0",
+    "organization": "xiaomi",
+    "provider": "xiaomiV1",
+    "publicName": "mimo-v2-flash",
+    "name": "mimo-v2-flash",
+    "displayName": "mimo-v2-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 122,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 55
+    }
+  },
+  {
+    "id": "5fd3caa8-fe4c-41a5-a22c-0025b58f4b42",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-5-mini-high",
+    "name": "gpt-5-mini-high",
+    "displayName": "gpt-5-mini-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 124,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "f1102bbf-34ca-468f-a9fc-14bcf63f315b",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "o4-mini-2025-04-16",
+    "name": "o4-mini-2025-04-16",
+    "displayName": "o4-mini-2025-04-16",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 125,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "ac44dd10-0666-451c-b824-386ccfea7bcc",
+    "organization": "anthropic",
+    "provider": "googleVertexAnthropic",
+    "publicName": "claude-sonnet-4-20250514",
+    "name": "claude-sonnet-4-20250514",
+    "displayName": "claude-sonnet-4-20250514",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 126,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "ba8c2392-4c47-42af-bfee-c6c057615a91",
+    "organization": "tencent",
+    "provider": "tencent",
+    "publicName": "hunyuan-t1-20250711",
+    "name": "hunyuan-t1-20250711",
+    "displayName": "hunyuan-t1-20250711",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 128,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "af033cbd-ec6c-42cc-9afa-e227fc12efe8",
+    "organization": "Alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-coder-480b-a35b-instruct",
+    "name": "qwen3-coder-480b-a35b-instruct",
+    "displayName": "qwen3-coder-480b-a35b-instruct",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 130,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 64
+    }
+  },
+  {
+    "id": "27b9f8c6-3ee1-464a-9479-a8b3c2a48fd4",
+    "organization": "mistral",
+    "provider": "mistral",
+    "publicName": "mistral-medium-2505",
+    "name": "mistral-medium-2505",
+    "displayName": "mistral-medium-2505",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 132,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019b4231-1994-75a1-8567-8cba308fba55",
+    "organization": "minimax",
+    "provider": "minimaxAnthropic",
+    "publicName": "minimax-m2.1-preview",
+    "name": "minimax-m2.1-preview",
+    "displayName": "minimax-m2.1-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 133,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 36
+    }
+  },
+  {
+    "id": "a8d1d310-e485-4c50-8f27-4bff18292a99",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-30b-a3b-instruct-2507",
+    "name": "qwen3-30b-a3b-instruct-2507",
+    "displayName": "qwen3-30b-a3b-instruct-2507",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 134,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "6a5437a7-c786-467b-b701-17b0bc8c8231",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-4.1-mini-2025-04-14",
+    "name": "gpt-4.1-mini-2025-04-14",
+    "displayName": "gpt-4.1-mini-2025-04-14",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 135,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c6e9c-b7f1-774b-8674-b0a795a49d8b",
+    "organization": "arcee-ai",
+    "provider": "arcee",
+    "publicName": "trinity-large",
+    "name": "trinity-large",
+    "displayName": "trinity-large-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 139,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "2595a594-fa54-4299-97cd-2d7380d21c80",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-235b-a22b",
+    "name": "qwen3-235b-a22b",
+    "displayName": "qwen3-235b-a22b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 140,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d50aa-447d-74d6-8661-405b4b6de5de",
+    "organization": "arcee-ai",
+    "provider": "arceeToolCalling",
+    "publicName": "trinity-large-thinking",
+    "name": "trinity-large-thinking",
+    "displayName": "trinity-large-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 144,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 67
+    }
+  },
+  {
+    "id": "73cf8705-98c8-4b75-8d04-e3746e1c1565",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-next-80b-a3b-thinking",
+    "name": "qwen3-next-80b-a3b-thinking",
+    "displayName": "qwen3-next-80b-a3b-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 147,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "789e245f-eafe-4c72-b563-d135e93988fc",
+    "organization": "google",
+    "provider": "google",
+    "publicName": "gemma-3-27b-it",
+    "name": "gemma-3-27b-it",
+    "displayName": "gemma-3-27b-it",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 150,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "87e8d160-049e-4b4e-adc4-7f2511348539",
+    "organization": "minimax",
+    "provider": "minimax",
+    "publicName": "minimax-m1",
+    "name": "minimax-m1",
+    "displayName": "minimax-m1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 151,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "149619f1-f1d5-45fd-a53e-7d790f156f20",
+    "organization": "xai",
+    "provider": "xaiPublic",
+    "publicName": "grok-3-mini-high",
+    "name": "grok-3-mini-high",
+    "displayName": "grok-3-mini-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 153,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cbb13-c727-76ef-ba21-4f3affc274c6",
+    "publicName": "march26-chatbot1",
+    "displayName": "march26-chatbot1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 154,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "7a55108b-b997-4cff-a72f-5aa83beee918",
+    "organization": "google",
+    "provider": "google",
+    "publicName": "gemini-2.0-flash-001",
+    "name": "gemini-2.0-flash-001",
+    "displayName": "gemini-2.0-flash-001",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 155,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "bbad1d17-6aa5-4321-949c-d11fb6289241",
+    "organization": "mistral",
+    "provider": "mistral",
+    "publicName": "mistral-small-2506",
+    "name": "mistral-small-2506",
+    "displayName": "mistral-small-2506",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 157,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "7699c8d4-0742-42f9-a117-d10e84688dab",
+    "organization": "xai",
+    "provider": "xaiPublic",
+    "publicName": "grok-3-mini-beta",
+    "name": "grok-3-mini-beta",
+    "displayName": "grok-3-mini-beta",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 158,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019aebfd-af0e-7f0c-8f0d-96c588e4cd3b",
+    "organization": "prime-intellect",
+    "provider": "openrouter",
+    "publicName": "intellect-3",
+    "name": "intellect-3",
+    "displayName": "intellect-3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 159,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "6ee9f901-17b5-4fbe-9cc2-13c16497c23b",
+    "organization": "openai",
+    "provider": "fireworks",
+    "publicName": "gpt-oss-120b",
+    "name": "gpt-oss-120b",
+    "displayName": "gpt-oss-120b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 163,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "1ea13a81-93a7-4804-bcdd-693cd72e302d",
+    "organization": "stepfun",
+    "provider": "stepfun",
+    "publicName": "step-3",
+    "name": "step-3",
+    "displayName": "step-3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 167,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "c680645e-efac-4a81-b0af-da16902b2541",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "o3-mini",
+    "name": "o3-mini",
+    "displayName": "o3-mini",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 169,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cc65f-c1e3-7574-b332-898ab71c8211",
+    "organization": "inception-ai",
+    "provider": "openrouter",
+    "publicName": "mercury-2",
+    "name": "mercury-2",
+    "displayName": "mercury-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 172,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 77
+    }
+  },
+  {
+    "id": "71f96ca9-4cf8-4be7-bac2-2231613930a6",
+    "organization": "ant-group",
+    "provider": "antgroup",
+    "publicName": "ling-flash-2.0",
+    "name": "ling-flash-2.0",
+    "displayName": "ling-flash-2.0",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 173,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a27e0-e7d8-7b0b-877c-a2106c6eb87d",
+    "organization": "minimax",
+    "provider": "minimax",
+    "publicName": "minimax-m2",
+    "name": "minimax-m2",
+    "displayName": "minimax-m2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 174,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 61
+    }
+  },
+  {
+    "id": "2dc249b3-98da-44b4-8d1e-6666346a8012",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-5-nano-high",
+    "name": "gpt-5-nano-high",
+    "displayName": "gpt-5-nano-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 182,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ae300-83b7-7717-a1e0-31accd1ff6fa",
+    "organization": "amazon",
+    "provider": "amazonBedrock",
+    "publicName": "nova-2-lite",
+    "name": "global.amazon.nova-2-lite-v1:0",
+    "displayName": "nova-2-lite",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 183,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "885976d3-d178-48f5-a3f4-6e13e0718872",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwq-32b",
+    "name": "qwq-32b",
+    "displayName": "qwq-32b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 185,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ba0c1-d519-718c-b125-e6297f581232",
+    "organization": "allenai",
+    "provider": "openrouter",
+    "publicName": "olmo-3.1-32b-instruct",
+    "name": "olmo-3.1-32b-instruct",
+    "displayName": "olmo-3.1-32b-instruct",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 192,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c34f1-2c68-7f1a-b8cd-00f29110573b",
+    "organization": "allenai",
+    "provider": "openrouter",
+    "publicName": "molmo-2-8b",
+    "name": "molmo-2-8b",
+    "displayName": "molmo-2-8b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 194,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "9a066f6a-7205-4325-8d0b-d81cc4b049c0",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-30b-a3b",
+    "name": "qwen3-30b-a3b",
+    "displayName": "qwen3-30b-a3b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 196,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "11ad4114-c868-4fed-b6e7-d535dc9c62f8",
+    "organization": "ant-group",
+    "provider": "antgroup",
+    "publicName": "ring-flash-2.0",
+    "name": "ring-flash-2.0",
+    "displayName": "ring-flash-2.0",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 206,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "896a3848-ae03-4651-963b-7d8f54b61ae8",
+    "organization": "google",
+    "provider": "google",
+    "publicName": "gemma-3n-e4b-it",
+    "name": "gemma-3n-e4b-it",
+    "displayName": "gemma-3n-e4b-it",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 209,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "dcbd7897-5a37-4a34-93f1-76a24c7bb028",
+    "organization": "meta",
+    "provider": "fireworks",
+    "publicName": "llama-3.3-70b-instruct",
+    "name": "llama-3.3-70b-instruct",
+    "displayName": "llama-3.3-70b-instruct",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 210,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "ec3beb4b-7229-4232-bab9-670ee52dd711",
+    "organization": "openai",
+    "provider": "fireworks",
+    "publicName": "gpt-oss-20b",
+    "name": "gpt-oss-20b",
+    "displayName": "gpt-oss-20b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 213,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019b0aa7-334a-78e8-b2a8-885f31f4fc0c",
+    "organization": "nvidia",
+    "provider": "nvidia",
+    "publicName": "nvidia-nemotron-3-nano-30b-a3b-bf16",
+    "name": "december-chatbot",
+    "displayName": "nvidia-nemotron-3-nano-30b-a3b-bf16",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 214,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019de522-c5eb-722f-a907-c79891cc6795",
+    "organization": "ibm",
+    "provider": "openrouter",
+    "publicName": "granite-4.1-8b",
+    "name": "granite-4.1-8b",
+    "displayName": "granite-4.1-8b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 220,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 75
+    }
+  },
+  {
+    "id": "019a6f77-e20d-7c1d-a7cd-8bd926e7395d",
+    "organization": "inception-ai",
+    "provider": "openrouter",
+    "publicName": "mercury",
+    "name": "mercury",
+    "displayName": "mercury",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 225,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ac2ef-27e1-769f-8258-d131f79e28ef",
+    "organization": "allenai",
+    "provider": "openrouter",
+    "publicName": "olmo-3-32b-think",
+    "name": "olmo-3-32b-think",
+    "displayName": "olmo-3-32b-think",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 227,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "69f5d38a-45f5-4d3a-9320-b866a4035ed9",
+    "organization": "mistral",
+    "provider": "mistral",
+    "publicName": "mistral-small-3.1-24b-instruct-2503",
+    "name": "mistral-small-3.1-24b-instruct-2503",
+    "displayName": "mistral-small-3.1-24b-instruct-2503",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 231,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "4ddb69f5-391a-4f78-af92-7d7328c18ab1",
+    "organization": "ibm",
+    "provider": "ibm",
+    "publicName": "ibm-granite-h-small",
+    "name": "ibm-granite-h-small",
+    "displayName": "ibm-granite-h-small",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 240,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ba559-2883-7a05-b012-bf6c2d38fa86",
+    "organization": "allenai",
+    "provider": "openrouter",
+    "publicName": "olmo-3.1-32b-think",
+    "name": "olmo-3.1-32b-think-v2",
+    "displayName": "olmo-3.1-32b-think",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 245,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc595-1a8e-7581-91bf-fa532e483a87",
+    "publicName": "jebel_1",
+    "displayName": "jebel_1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019df929-5b0c-7935-acf6-82fb0264ef9e",
+    "publicName": "scooter",
+    "displayName": "scooter",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc595-4615-731e-a09a-5b3643a216a0",
+    "publicName": "jebel_2",
+    "displayName": "jebel_2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c6e77-1b9f-7649-9136-43d07566c6c5",
+    "organization": "ant-group",
+    "provider": "antgroup",
+    "publicName": "ring-2.5-1t",
+    "name": "ring-2.5-1t-20260217",
+    "displayName": "ring-2.5-1t",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e0d72-cd11-7ca4-89e9-743a1df2a7dd",
+    "publicName": "kira-star",
+    "displayName": "kira-star",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ddf34-bf27-7df6-8cba-35ac93ccbe7f",
+    "publicName": "tetra-0429-1",
+    "displayName": "tetra-0429-1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ca598-ee91-746e-939f-16539b092010",
+    "publicName": "ember",
+    "displayName": "ember",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e003d-d328-7d7b-9023-9806449ba243",
+    "publicName": "artemis_1",
+    "displayName": "artemis_1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e003d-f2b8-7a72-a164-429e9fef5a67",
+    "publicName": "artemis_2",
+    "displayName": "artemis_2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019df929-7268-7b2e-8383-8e674ff98b3b",
+    "publicName": "rover",
+    "displayName": "rover",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ddf34-fdee-7e14-bdba-d739a2226467",
+    "publicName": "tetra-0429-2",
+    "displayName": "tetra-0429-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ddf35-3ac3-79a0-88c6-f3724e614513",
+    "publicName": "tetra-0429-3",
+    "displayName": "tetra-0429-3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c6eda-f717-7497-bdbb-d2804ac23691",
+    "publicName": "steed-0217",
+    "displayName": "steed-0217",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e46fa-b37c-74d1-9871-334a2429306f",
+    "publicName": "may26-chatbot3",
+    "displayName": "may26-chatbot3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ddf1e-8098-7696-9f1b-71ced5c4b4a7",
+    "publicName": "kiteki-beta",
+    "displayName": "kiteki-beta",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ddf35-769d-7c63-9590-6ac742c73da5",
+    "publicName": "tetra-0429-4",
+    "displayName": "tetra-0429-4",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ddf35-be93-7d59-b054-7b7458ec0c03",
+    "publicName": "tetra-0429-5",
+    "displayName": "tetra-0429-5",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d78d3-f33f-7325-a76b-7eb9bd4eeeea",
+    "publicName": "hofburg-1",
+    "displayName": "hofburg-1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ca599-24b3-7204-8b62-e7286162888f",
+    "publicName": "pulse",
+    "displayName": "pulse",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e00ee-f6bf-7593-9f5b-d91757d47b21",
+    "publicName": "mivan",
+    "displayName": "mivan",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ddf36-1896-70d5-b420-1cf8c2030749",
+    "publicName": "tetra-0429-6",
+    "displayName": "tetra-0429-6",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e3bb9-3b63-7173-a1ac-07d837b47478",
+    "publicName": "maylynx-alpha",
+    "displayName": "maylynx-alpha",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc114-50a4-786e-a0e6-a4ebcd2c3d0c",
+    "publicName": "cloud-buddy",
+    "displayName": "cloud-buddy",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e2cbc-046f-714a-9aa4-1094caf7b571",
+    "publicName": "luxor",
+    "displayName": "luxor",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cd3cd-1298-7604-80f0-a46b16f9add0",
+    "publicName": "pisces-0309",
+    "displayName": "pisces-0309",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ddf4c-1d0e-76e9-95b6-73e90db242da",
+    "publicName": "pakson",
+    "displayName": "pakson",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e222c-36d0-76cb-bf4a-a41a2ae809ba",
+    "publicName": "may-beta",
+    "displayName": "may-beta",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c6e76-fbbc-7e92-b0ba-784c7ef3ad8b",
+    "organization": "ant-group",
+    "provider": "antgroup",
+    "publicName": "ling-2.5-1t",
+    "name": "ling-2.5-1t",
+    "displayName": "ling-2.5-1t",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d78f7-5e8d-7b01-94e3-65ed4918bd4d",
+    "publicName": "globe_2",
+    "displayName": "globe_2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d44f1-26da-729f-a4ea-ddddfe7b4eae",
+    "organization": "baidu",
+    "provider": "baidubce",
+    "publicName": "ernie-5.0-preview-1220",
+    "name": "ernie-5.0-preview-1220",
+    "displayName": "ernie-5.0-preview-1220",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c6453-641a-74f8-a689-a8a67175a359",
+    "organization": "bytedance",
+    "provider": "bytedanceark",
+    "publicName": "dola-seed-2.0-preview-vision",
+    "name": "dola-seed-2.0-preview-vision",
+    "displayName": "dola-seed-2.0-preview-vision",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cfdfe-6e21-7d6f-bea9-88db022db730",
+    "publicName": "anonymous-1800",
+    "displayName": "anonymous-1800",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "0199c1d5-51b8-7ead-a0a8-3f59234682fa",
+    "publicName": "gpt-5-high-no-system-prompt",
+    "displayName": "gpt-5-high-no-system-prompt",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c4915-16ec-782c-abb2-4e4e73916394",
+    "publicName": "mammoth-newt-0206",
+    "displayName": "mammoth-newt-0206",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019cd857-d6e2-75e3-940e-b5ef0e92e62a",
+    "publicName": "pisces-0226d",
+    "displayName": "pisces-0226d",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d7a65-02da-7d73-9011-4d12f2793e2b",
+    "publicName": "hofburg_2",
+    "displayName": "hofburg_2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cd858-3983-7ef2-9e04-4727ebab8472",
+    "publicName": "pisces-0226d",
+    "displayName": "pisces-0226d",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d0303-d7ed-774d-a922-3115d4516e76",
+    "publicName": "pisces-0318-vision",
+    "displayName": "pisces-0318-vision",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cd9e3-c3ff-7225-92f2-c392259b1fbe",
+    "publicName": "march26-chatbot1-public",
+    "displayName": "march26-chatbot1-public",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "0199e3d1-a308-77b9-a650-41453e8ef2fb",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-vl-8b-thinking",
+    "name": "qwen3-vl-8b-thinking",
+    "displayName": "qwen3-vl-8b-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ce30b-a961-74f2-8ae1-3ac099e756f8",
+    "publicName": "pisces-0309-vision",
+    "displayName": "pisces-0309-vision",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d980d-4207-732c-b110-5a6587c1790d",
+    "publicName": "blue-forge",
+    "displayName": "blue-forge",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019aa97e-7b68-7c21-add9-b17edc20ff02",
+    "publicName": "anonymous-1111",
+    "displayName": "anonymous-1111",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d22e0-956a-7921-aa6f-67c696c698cf",
+    "publicName": "spark",
+    "displayName": "spark",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cdd8d-8142-7ad6-9a92-1119d449319e",
+    "publicName": "pisces-0309b",
+    "displayName": "pisces-0309b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d7b55-1220-764e-8a5a-5e177d5c8181",
+    "publicName": "hofburg_3",
+    "displayName": "hofburg_3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "9af435c8-1f53-4b78-a400-c1f5e9fe09b0",
+    "publicName": "leepwal",
+    "displayName": "leepwal",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a33c6-e248-7091-94c0-af68f29390b8",
+    "publicName": "blackhawk",
+    "displayName": "blackhawk",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc1bf-366c-7dc2-a8ea-5507ae80fcee",
+    "organization": "deepseek",
+    "provider": "deepseekToolCalling",
+    "publicName": "deepseek-v4-flash-thinking",
+    "name": "deepseek-v4-flash-thinking",
+    "displayName": "deepseek-v4-flash-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d22e0-5ffe-776a-811c-f44d1c20918c",
+    "publicName": "hearth",
+    "displayName": "hearth",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cdd8e-4c55-74c1-ab6a-77d38e9275a0",
+    "publicName": "pisces-0309b",
+    "displayName": "pisces-0309b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "19ad5f04-38c6-48ae-b826-f7d5bbfd79f7",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-5-high-new-system-prompt",
+    "name": "gpt-5-high-new-system-prompt",
+    "displayName": "gpt-5-high-new-system-prompt",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019db753-2ce6-77e2-a2e1-c2db9b7f5640",
+    "publicName": "happy-friday-testing-1",
+    "displayName": "happy-friday-testing-1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d55f6-138e-78d3-a831-c338940f1836",
+    "publicName": "scorch",
+    "displayName": "scorch",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d06ba-bd13-75bb-b5ee-2ed495c57756",
+    "publicName": "beluga-0311-1",
+    "displayName": "beluga-0311-1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "0304b4de-e544-48d4-8490-ad9123bc26e3",
+    "publicName": "monster",
+    "displayName": "monster",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d2ac4-713c-7ea3-baac-26b313dda937",
+    "publicName": "dola-seed-2.0-pro-vision",
+    "displayName": "dola-seed-2.0-pro-vision",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "d8444b25-e302-4d3b-8561-7ded087ee03c",
+    "publicName": "monterey",
+    "displayName": "monterey",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c9719-4d29-7e78-95ed-2cb3319494d1",
+    "publicName": "february26-chatbot4",
+    "displayName": "february26-chatbot4",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a7b93-af36-7f06-bb46-2b6b0548fc93",
+    "publicName": "whisperfall",
+    "displayName": "whisperfall",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a842c-7e62-725a-8a2a-f76f5ec786dd",
+    "publicName": "neon",
+    "displayName": "neon",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d82b0-4993-79d9-a6fd-e46121a86029",
+    "publicName": "anonymous-1835",
+    "displayName": "anonymous-1835",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cbb43-193c-770a-8e59-155f72b84e44",
+    "publicName": "mammoth-newt-0226",
+    "displayName": "mammoth-newt-0226",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a6c82-2ead-7475-8612-55dabba11c31",
+    "publicName": "viper",
+    "displayName": "viper",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d688c-b540-75ff-994d-338e3aec20ce",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3.6-plus",
+    "name": "qwen3.6-plus-text",
+    "displayName": "qwen3.6-plus",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d412c-1425-7e7f-afde-48f0957ae525",
+    "publicName": "anonymous-1825",
+    "displayName": "anonymous-1825",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "48fe3167-5680-4903-9ab5-2f0b9dc05815",
+    "publicName": "nightride-on",
+    "displayName": "nightride-on",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a19ad-a47e-7828-aa1f-5c7f2c4f65fe",
+    "publicName": "ring-1t",
+    "displayName": "ring-1t",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "c822ec98-38e9-4e43-a434-982eb534824f",
+    "publicName": "nightride-on-v2",
+    "displayName": "nightride-on-v2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c9af7-7985-7508-8dc9-0795652c421f",
+    "publicName": "zephyr",
+    "displayName": "zephyr",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d0303-4f28-718c-bf82-e0965659bbcc",
+    "publicName": "pisces-0318-text",
+    "displayName": "pisces-0318-text",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ce84b-5299-7477-9386-8d56c3d6ab2f",
+    "publicName": "pisces-0309c",
+    "displayName": "pisces-0309c",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ce84b-7f93-7ae5-9ef5-cec6ea41c4a6",
+    "publicName": "pisces-0309c",
+    "displayName": "pisces-0309c",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "6c98ce8c-41d1-42cd-b2e3-292c6519add5",
+    "publicName": "redwood",
+    "displayName": "redwood",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d3529-e393-7324-a575-79b765c45e8a",
+    "publicName": "yivon-beta",
+    "displayName": "yivon-beta",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d352a-1430-7c87-933e-16be2e3c8fbc",
+    "publicName": "atlas",
+    "displayName": "atlas",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c9af8-5ed9-7cbc-831b-c485e8fe977b",
+    "publicName": "vortex",
+    "displayName": "vortex",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d449a-2ac9-72f8-9e00-16ed16121325",
+    "publicName": "march26-chatbot2",
+    "displayName": "march26-chatbot2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d449a-8ba5-7279-af36-6ebe6b11fc0e",
+    "publicName": "march26-chatbot3",
+    "displayName": "march26-chatbot3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d5975-ed63-765e-8411-a2fe506b12a4",
+    "publicName": "karyu",
+    "displayName": "karyu",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d926e-7d01-7f5a-9ebd-cbaef6df34d8",
+    "publicName": "botbot2",
+    "displayName": "botbot2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true,
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991,
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019d44e9-d934-701b-b936-10932c4fc0d2",
+    "publicName": "orion",
+    "displayName": "orion",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d0cda-66eb-7736-a1d7-f8545eae2b55",
+    "publicName": "pisces-0320",
+    "displayName": "pisces-0320",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d0cda-e268-7081-a68a-0bfb9e995ad7",
+    "publicName": "pisces-0320",
+    "displayName": "pisces-0320",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d45cf-a650-7bc4-bc44-f6e26c892ced",
+    "publicName": "duomo-1-hero",
+    "displayName": "duomo-1-hero",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019db1aa-0f8d-78bf-9d9d-d02dd20c94ca",
+    "publicName": "happy-friday-testing-1",
+    "displayName": "happy-friday-testing-1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019b5da6-19e7-7dcd-8387-e6bac5d6145e",
+    "publicName": "anonymous-1218",
+    "displayName": "anonymous-1218",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cefb0-5816-7237-bbd4-7e2e180936a0",
+    "publicName": "zeylu-alpha",
+    "displayName": "zeylu-alpha",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cefb0-9813-72c9-934a-47ae122b0c52",
+    "publicName": "zeylu-beta",
+    "displayName": "zeylu-beta",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cf247-984e-72e6-93d6-ee4d0d7c8ee1",
+    "publicName": "clawl",
+    "displayName": "clawl",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a184d-efba-7743-979a-324e949aa1c4",
+    "publicName": "ernie-exp-251024",
+    "displayName": "ernie-exp-251024",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d932e-b539-7213-b395-bfd046a6db82",
+    "publicName": "minicpm-sala",
+    "displayName": "minicpm-sala",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019b5da7-c6eb-73f2-b228-0c1e8e1c77ce",
+    "publicName": "anonymous-1221",
+    "displayName": "anonymous-1221",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e3d70-aa81-7f4d-ac56-b08c0b7609a0",
+    "publicName": "u2-preview",
+    "displayName": "u2-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c4dd1-1582-711c-813c-459afb6000b7",
+    "publicName": "vierra",
+    "displayName": "vierra",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c4dd1-53d2-75ba-bfd2-2da534f9d338",
+    "publicName": "rotten-apple",
+    "displayName": "rotten-apple",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cfcb1-61a1-7468-86a6-4bd1ca51b50d",
+    "publicName": "pisces-0309d",
+    "displayName": "pisces-0309d",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "39b185cb-aba9-4232-99ea-074883a5ccd4",
+    "publicName": "stephen-v2",
+    "displayName": "stephen-v2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cfcb2-499b-70d6-bce7-082a93e83cfe",
+    "publicName": "pisces-0309d",
+    "displayName": "pisces-0309d",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d938b-22e5-761d-a314-2adbb1f8b0a5",
+    "publicName": "yotta-nexus",
+    "displayName": "yotta-nexus",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019be747-2da8-760b-a811-1ac9442106d0",
+    "publicName": "queen-bee",
+    "displayName": "queen-bee",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c95c7-d2b2-7586-8482-1cf973f9d127",
+    "organization": "xai",
+    "provider": "xaiApi",
+    "publicName": "grok-4.20-beta1",
+    "name": "grok-4.20-beta1",
+    "displayName": "grok-4.20-beta1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "638fb8b8-1037-4ee5-bfba-333392575a5d",
+    "publicName": "EB45-vision",
+    "displayName": "EB45-vision",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c0d66-8d57-74e4-b680-0003cb600b70",
+    "publicName": "pisces-llm-0130",
+    "displayName": "pisces-llm-0130",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c59c3-0e69-713f-9afe-20f5b3b1e0df",
+    "publicName": "february26-chatbot2",
+    "displayName": "february26-chatbot2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c59c3-2a2d-73a3-85aa-355a6ac568a8",
+    "publicName": "february26-chatbot3",
+    "displayName": "february26-chatbot3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c59c3-4fd1-753a-984f-10791bd955e5",
+    "publicName": "clinkz",
+    "displayName": "clinkz",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c6255-9621-78ab-8ea5-391eb7af9b75",
+    "publicName": "velo",
+    "displayName": "velo",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019c6453-8727-7186-9523-e130170d2fb9",
+    "organization": "bytedance",
+    "provider": "bytedanceark",
+    "publicName": "dola-seed-2.0-preview-text",
+    "name": "dola-seed-2.0-preview-text",
+    "displayName": "dola-seed-2.0-preview-text",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019b80de-be75-7165-9b85-438eb7d021ff",
+    "publicName": "kiwi-do",
+    "displayName": "kiwi-do",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "e9dd5a96-c066-48b0-869f-eb762030b5ed",
+    "publicName": "EB45-turbo",
+    "displayName": "EB45-turbo",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019be171-20f6-7c7d-a31e-60fc4b90ee78",
+    "publicName": "raptor-1.8-0120",
+    "displayName": "raptor-1.8-0120",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "e3c9ea42-5f42-496b-bc80-c7e8ee5653cc",
+    "publicName": "stephen-vision-csfix",
+    "displayName": "stephen-vision-csfix",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ab9ad-caac-78f4-8007-bf0e082771d0",
+    "publicName": "raptor-1123",
+    "displayName": "raptor-1123",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019ab9ad-d128-7858-8745-6da5936ccb5e",
+    "publicName": "raptor-1124",
+    "displayName": "raptor-1124",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019b287d-9ffc-7ce4-95be-d93929cdd94f",
+    "publicName": "step-3-mini-2511",
+    "displayName": "step-3-mini-2511",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "0199eb70-db25-73ea-b944-f18fe0c3c0cd",
+    "publicName": "ernie-exp-vl-251016",
+    "displayName": "ernie-exp-vl-251016",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc09e-756d-74cd-92ab-ff6e7d71b6b8",
+    "publicName": "happy-friday-testing-2",
+    "displayName": "happy-friday-testing-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "0199edd2-88be-76b8-9aaa-5fc6b9c53503",
+    "publicName": "ling-1t",
+    "displayName": "ling-1t",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a3e64-eae6-7178-a9ae-2894c25ada46",
+    "publicName": "sunshine-ai",
+    "displayName": "sunshine-ai",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e4126-2c14-74d0-b898-1a08462025e1",
+    "publicName": "kimi-k2.6",
+    "displayName": "kimi-k2.6",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019a1dce-b0d7-75cc-8742-997a0639f061",
+    "publicName": "ernie-exp-251025",
+    "displayName": "ernie-exp-251025",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a19ad-8f50-7282-8cb9-5e49b9052aff",
+    "publicName": "ernie-exp-251023",
+    "displayName": "ernie-exp-251023",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "0199de70-e6ad-7276-9020-a7502bed99ad",
+    "publicName": "flying-octopus",
+    "displayName": "flying-octopus",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a26b4-2540-7a7d-96bf-b6b377e8d1ec",
+    "publicName": "ernie-exp-251026",
+    "displayName": "ernie-exp-251026",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a26b4-2a20-7864-b1f7-d471ec1f4e3f",
+    "publicName": "ernie-exp-251027",
+    "displayName": "ernie-exp-251027",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019aa3fb-ec59-7b49-af33-57d0981509e0",
+    "publicName": "ling-1t-1031",
+    "displayName": "ling-1t-1031",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d6f03-0a09-72d7-9f40-8d99454e68a0",
+    "publicName": "april26-chatbot1",
+    "displayName": "april26-chatbot1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d6f03-4632-772e-97cb-debfa5452860",
+    "publicName": "april26-chatbot2",
+    "displayName": "april26-chatbot2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d97b9-605a-7251-b5a3-559118c38cc0",
+    "publicName": "hofburg_4",
+    "displayName": "hofburg_4",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a3aeb-371d-7474-a1b7-b8f4207a9a2c",
+    "publicName": "qwen3-max-2025-10-30",
+    "displayName": "qwen3-max-2025-10-30",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d97b9-8b6c-7beb-957b-4cf7eb645a91",
+    "publicName": "hofburg_5",
+    "displayName": "hofburg_5",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d2cd2-dd83-75ab-a421-d0ba2e22b1e3",
+    "organization": "google",
+    "provider": "googleWithThoughtSignatures",
+    "publicName": "pteronura",
+    "name": "pteronura",
+    "displayName": "gemma-4-31b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        },
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019db6eb-5e1f-7087-8d4d-9199143accf1",
+    "publicName": "solar-eclipse",
+    "displayName": "solar-eclipse",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d97d0-c5ab-7016-a9d9-9484cccb45a2",
+    "publicName": "apex-atlas",
+    "displayName": "apex-atlas",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d0dd2-89e1-794c-a124-d06aff5c354d",
+    "publicName": "anonymous-1815",
+    "displayName": "anonymous-1815",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019df8ec-2d44-79d8-a629-d518b48e7d09",
+    "publicName": "moryn",
+    "displayName": "moryn",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d2cd3-2641-7628-94bd-67ecb0a7134e",
+    "organization": "google",
+    "provider": "googleWithThoughtSignatures",
+    "publicName": "significant-otter",
+    "name": "significant-otter",
+    "displayName": "gemma-4-26b-a4b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d308f-e3c0-72e5-b819-f51d807653df",
+    "organization": "moonshot",
+    "provider": "moonshot",
+    "publicName": "kimi-k2.5",
+    "name": "kimi-k2.5-20260327",
+    "displayName": "kimi-k2.5-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019dfa7d-930c-75ab-9f8c-740dbf7ac5ec",
+    "publicName": "tetra-0505-1",
+    "displayName": "tetra-0505-1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dfa7d-cd37-78c1-a662-608b631633e1",
+    "publicName": "tetra-0505-2",
+    "displayName": "tetra-0505-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dd034-4403-7578-a75c-54fb69d92ec6",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.5-xhigh",
+    "name": "gpt-5.5-xhigh",
+    "displayName": "gpt-5.5-xhigh",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": false,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019cf983-532b-73fa-a057-7658e1e1c5ee",
+    "organization": "mistral",
+    "provider": "mistral",
+    "publicName": "mistral-small-2603",
+    "name": "mistral-small-2603",
+    "displayName": "mistral-small-2603",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc239-99a2-7747-9042-d1c47c8a3c24",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3.6-27b",
+    "name": "qwen3.6-27b",
+    "displayName": "qwen3.6-27b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019dd1e6-05cc-70f3-9900-b604b1edfa46",
+    "publicName": "april26-chatbot3",
+    "displayName": "april26-chatbot3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc1c1-89b1-7588-a7fd-a6132ddb734c",
+    "organization": "deepseek",
+    "provider": "deepseek",
+    "publicName": "deepseek-v4-pro",
+    "name": "deepseek-v4-pro-public",
+    "displayName": "deepseek-v4-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019daede-adf8-7f17-8545-d840f387a75c",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "kizen-alpha",
+    "name": "kizen-alpha",
+    "displayName": "qwen3.6-max-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019de42c-5c72-7c36-8b55-6abafffbb8ae",
+    "publicName": "miyami",
+    "displayName": "miyami",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e2dc1-5604-79a3-92e3-cd8578960cd9",
+    "publicName": "kimi-k2.6",
+    "displayName": "kimi-k2.6",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019becd0-3441-759d-910f-30899f2c95ef",
+    "organization": "zai",
+    "provider": "fireworks",
+    "publicName": "glm-4.7-flash",
+    "name": "glm-4.7-flash-fireworks",
+    "displayName": "glm-4.7-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019e2dc2-0e07-7772-a3e3-8db3790f4d1c",
+    "publicName": "deepseek-v4-pro",
+    "displayName": "deepseek-v4-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019e2dc2-4991-7f7b-af53-d7743a937b14",
+    "publicName": "deepseek-v4-flash",
+    "displayName": "deepseek-v4-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019e2dc2-c89a-7c0d-88e8-10f1a0baeeca",
+    "publicName": "minimax-m2.7",
+    "displayName": "minimax-m2.7",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019e2dc4-97df-70e7-9808-6453dde7605b",
+    "publicName": "qwen3.6-plus",
+    "displayName": "qwen3.6-plus",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019e2dfe-8104-7738-b35c-37f8a3ae5cae",
+    "publicName": "luxor-alt",
+    "displayName": "luxor-alt",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e2dff-e12a-7790-a846-520f73a5709a",
+    "publicName": "gemini-3.1-pro",
+    "displayName": "gemini-3.1-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019dac54-e8a4-7c54-904a-ff0ecd82af42",
+    "organization": "moonshot",
+    "provider": "moonshot",
+    "publicName": "kimi-k2.6",
+    "name": "kimi-k2.6-20260420",
+    "displayName": "kimi-k2.6",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e27a8-6c30-7dcc-bd39-4b629dd851eb",
+    "publicName": "chickadee",
+    "displayName": "chickadee",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019a17b5-5e1e-7df6-9e1a-6c4338f8b6ff",
+    "organization": "minimax",
+    "provider": "minimax",
+    "publicName": "minimax-m2-preview",
+    "name": "minimax-m2-preview",
+    "displayName": "minimax-m2-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019de20c-ef1d-7b13-b8ee-087313ce197a",
+    "publicName": "coolers",
+    "displayName": "coolers",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019de20d-3bea-7007-a983-1ad49c0a44c8",
+    "publicName": "cooler",
+    "displayName": "cooler",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019de20d-8b9e-71ca-932c-e6b07d15cb55",
+    "publicName": "blankies",
+    "displayName": "blankies",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019df3e8-18e8-761a-8eeb-6c9f7f8f8114",
+    "publicName": "mekai",
+    "displayName": "mekai",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019db650-909d-7dec-8711-1907d7233cd4",
+    "organization": "xiaomi",
+    "provider": "xiaomiV1",
+    "publicName": "mimo-v2.5-pro",
+    "name": "mimo-v2.5-pro",
+    "displayName": "mimo-v2.5-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019de9ad-7752-7bbb-a5d3-dd64400fb106",
+    "publicName": "may26-chatbot1",
+    "displayName": "may26-chatbot1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc1c1-c62d-7b70-85a1-e0565e29fce1",
+    "organization": "deepseek",
+    "provider": "deepseekToolCalling",
+    "publicName": "deepseek-v4-pro-thinking",
+    "name": "deepseek-v4-pro-thinking-public",
+    "displayName": "deepseek-v4-pro-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "0199e3d1-a713-7de2-a5dd-a1583cad9532",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-vl-8b-instruct",
+    "name": "qwen3-vl-8b-instruct",
+    "displayName": "qwen3-vl-8b-instruct",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e222b-e8b3-7f0a-85db-daa010a64f3e",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "may-alpha",
+    "name": "may-alpha-0k1k",
+    "displayName": "qwen3.7-plus-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e128d-bc7d-744c-8854-67a38b15b3a1",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "melyora",
+    "name": "melyora-9qr6",
+    "displayName": "qwen3.7-max-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019db651-bd2f-7d80-ab12-d69c6bb623df",
+    "organization": "xiaomi",
+    "provider": "xiaomiV1",
+    "publicName": "mimo-v2.5",
+    "name": "mimo-v2.5",
+    "displayName": "mimo-v2.5",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019c6918-1d2a-7e3f-88ec-ada000b6ab16",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3.5-397b-a17b",
+    "name": "qwen3.5-397b-a17b",
+    "displayName": "qwen3.5-397b-a17b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019e04c9-ed3a-711d-b9e9-dee25ad7c177",
+    "publicName": "tetra-0507-1",
+    "displayName": "tetra-0507-1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e03bf-546c-7b6f-9db4-ec6c6660cbef",
+    "publicName": "steed-0507",
+    "displayName": "steed-0507",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e04cc-7faa-776c-b888-dd396d13a42c",
+    "publicName": "tetra-0507-4",
+    "displayName": "tetra-0507-4",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e04cc-9017-749b-a27e-ef792f76819e",
+    "publicName": "tetra-0507-2",
+    "displayName": "tetra-0507-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e04cc-9755-7277-94fc-d6fd4830028f",
+    "publicName": "tetra-0507-5",
+    "displayName": "tetra-0507-5",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e04cc-b8ff-7610-9cbd-889dce21ac93",
+    "publicName": "tetra-0507-3",
+    "displayName": "tetra-0507-3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e14a0-531b-76c5-a02d-0cff373a6dec",
+    "publicName": "artemis_3",
+    "displayName": "artemis_3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e14b1-fc7f-7c2f-b24e-ffc034fd4814",
+    "publicName": "artemis_4",
+    "displayName": "artemis_4",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc1bf-6338-7fef-8f87-991cc23b8fdc",
+    "organization": "deepseek",
+    "provider": "deepseek",
+    "publicName": "deepseek-v4-flash",
+    "name": "deepseek-v4-flash",
+    "displayName": "deepseek-v4-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019e460b-fd6e-74b4-9238-523e6ca3899c",
+    "publicName": "dark-matter",
+    "displayName": "dark-matter",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dfdf4-ce8c-7953-817a-0c436b733fe7",
+    "publicName": "mylen",
+    "displayName": "mylen",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "0199c9dc-e157-7458-bd49-5942363be215",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-omni-flash",
+    "name": "qwen3-omni-flash",
+    "displayName": "qwen3-omni-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "6fe1ec40-3219-4c33-b3e7-0e65658b4194",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen-vl-max-2025-08-13",
+    "name": "qwen-vl-max-2025-08-13",
+    "displayName": "qwen-vl-max-2025-08-13",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019bf8c6-3678-7e81-a0f7-0fe16e71d1cc",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-max-thinking",
+    "name": "qwen3-max-thinking",
+    "displayName": "qwen3-max-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e1d96-9710-760d-8299-1acaebc9e6c5",
+    "publicName": "may26-chatbot2",
+    "displayName": "may26-chatbot2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019e37c2-46ec-735c-bf5b-63f1c00ec573",
+    "organization": "google",
+    "provider": "googleWithThoughtSignatures",
+    "publicName": "gemini-3.5-flash",
+    "name": "ajax-20260517",
+    "displayName": "gemini-3.5-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019b5265-8405-799e-87af-199dc9f4ad4a",
+    "organization": "google",
+    "provider": "googleVertexGlobalWithThoughtSignatures",
+    "publicName": "gemini-3-flash (thinking-minimal)",
+    "name": "gemini-3-flash-thinking-minimal-fixed-20251224",
+    "displayName": "gemini-3-flash (thinking-minimal)",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019dfec2-612d-7c11-b54f-5236d830213d",
+    "publicName": "luna-hope",
+    "displayName": "luna-hope",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dfec2-6d88-77ba-b822-230ecbf14c56",
+    "publicName": "mira-sky",
+    "displayName": "mira-sky",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc0bb-d628-7eae-a09f-84cd023fe502",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.5",
+    "name": "gpt-5.5",
+    "displayName": "gpt-5.5",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": false,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc0b9-db53-792d-8034-dc7a7c9fad0c",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.5-high",
+    "name": "gpt-5.5-high",
+    "displayName": "gpt-5.5-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": false,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019de0aa-4638-7512-98c6-d4541702b37c",
+    "organization": "xai",
+    "provider": "xaiApi",
+    "publicName": "grok-4.3",
+    "name": "grok-4.3",
+    "displayName": "grok-4.3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "file": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "a14546b5-d78d-4cf6-bb61-ab5b8510a9d6",
+    "organization": "amazon",
+    "provider": "amazonBedrock",
+    "publicName": "amazon.nova-pro-v1:0",
+    "name": "amazon.nova-pro-v1:0",
+    "displayName": "amazon.nova-pro-v1:0",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d0764-4ab1-74d6-adb0-a03adcecce11",
+    "organization": "xiaomi",
+    "provider": "xiaomiV1",
+    "publicName": "mimo-v2-omni",
+    "name": "mimo-v2-omni",
+    "displayName": "mimo-v2-omni",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "ac31e980-8bf1-4637-adba-cf9ffa8b6343",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-max-2025-09-26",
+    "name": "qwen3-max-2025-09-26",
+    "displayName": "qwen3-max-2025-09-26",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d5e8d-d53e-75f3-bcf5-815ae0cf202a",
+    "organization": "zai",
+    "provider": "siliconFlowToolCalling",
+    "publicName": "glm-5.1",
+    "name": "glm-5.1",
+    "displayName": "glm-5.1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "text": true,
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991,
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d4a09-9651-78cb-86ea-bb0fa5ec77f4",
+    "organization": "zai",
+    "provider": "siliconFlow",
+    "publicName": "glm-5v-turbo",
+    "name": "glm-5v-turbo",
+    "displayName": "glm-5v-turbo",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "text": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "chat": 9007199254740991
+    }
+  },
+  {
+    "id": "019d8ec6-a30a-7f77-bba4-2a23e79a6132",
+    "publicName": "quiet_sand",
+    "displayName": "muse-spark",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 8,
+    "rankByModality": {
+      "webdev": 8
+    }
+  },
+  {
+    "id": "019e2d5a-f53c-785f-b54e-2a1b1b1c4c80",
+    "publicName": "muse-spark",
+    "displayName": "muse-spark",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 8,
+    "rankByModality": {
+      "webdev": 8
+    }
+  },
+  {
+    "id": "019e271b-c707-75eb-8d1c-b96d8073f3f8",
+    "organization": "google",
+    "provider": "googleWithThoughtSignatures",
+    "publicName": "gemini-3.5-flash",
+    "name": "ajax-gf",
+    "displayName": "gemini-3.5-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 9,
+    "rankByModality": {
+      "webdev": 9
+    }
+  },
+  {
+    "id": "019d6e6f-5eff-7584-a51d-376e01b77598",
+    "organization": "google",
+    "publicName": "gemini-3.1-pro-preview",
+    "displayName": "gemini-3.1-pro-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 19,
+    "rankByModality": {
+      "webdev": 19
+    }
+  },
+  {
+    "id": "019d91d3-bbc0-731b-9b21-c7351fb0780a",
+    "organization": "google",
+    "publicName": "gemini-3.1-pro-preview",
+    "displayName": "gemini-3.1-pro-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 19,
+    "rankByModality": {
+      "webdev": 19
+    }
+  },
+  {
+    "id": "019dc23a-fa4b-7469-9339-fc5254442b05",
+    "organization": "google",
+    "publicName": "gemini-3.1-pro-preview",
+    "displayName": "gemini-3.1-pro-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 19,
+    "rankByModality": {
+      "webdev": 19
+    }
+  },
+  {
+    "id": "019becd0-699c-7fc0-b10c-16ddb5ab9ea0",
+    "organization": "zai",
+    "provider": "fireworks",
+    "publicName": "glm-4.7",
+    "name": "glm-4.7-web-fireworks",
+    "displayName": "glm-4.7",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 21,
+    "rankByModality": {
+      "webdev": 21
+    }
+  },
+  {
+    "id": "019d502c-6bd3-7714-b1de-247f0e7aa9e1",
+    "organization": "google",
+    "publicName": "gemini-3-pro",
+    "displayName": "gemini-3-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 22,
+    "rankByModality": {
+      "webdev": 22
+    }
+  },
+  {
+    "id": "019dc23b-2470-7047-b336-b7f2f864dc25",
+    "organization": "google",
+    "publicName": "gemini-3-flash",
+    "displayName": "gemini-3-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 25,
+    "rankByModality": {
+      "webdev": 25
+    }
+  },
+  {
+    "id": "019e3e9d-ca77-77de-8e4a-a3208e849388",
+    "organization": "google",
+    "publicName": "gemini-3-flash",
+    "displayName": "gemini-3-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 25,
+    "rankByModality": {
+      "webdev": 25
+    }
+  },
+  {
+    "id": "019e132d-8508-7f1b-b937-9274fb1417b6",
+    "organization": "google",
+    "publicName": "gemini-3-flash",
+    "displayName": "gemini-3-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 25,
+    "rankByModality": {
+      "webdev": 25
+    }
+  },
+  {
+    "id": "019de0fb-8644-7917-96d1-1c2dd4a25d4b",
+    "organization": "google",
+    "publicName": "gemini-3-flash",
+    "displayName": "gemini-3-flash",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 25,
+    "rankByModality": {
+      "webdev": 25
+    }
+  },
+  {
+    "id": "019cc0bf-aeb3-7a0f-9982-dab440effef3",
+    "organization": "openai",
+    "provider": "openaiResponsesWithPhase",
+    "publicName": "gpt-5.3-codex",
+    "name": "gpt-5.3-codex-2026-03-05",
+    "displayName": "gpt-5.3-codex",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 30,
+    "rankByModality": {
+      "webdev": 30
+    }
+  },
+  {
+    "id": "019d0397-20a6-7e01-8bc6-ec5df604696d",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.4-mini-high",
+    "name": "gpt-5.4-mini-high-codex-harness",
+    "displayName": "gpt-5.4-mini-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 33,
+    "rankByModality": {
+      "webdev": 33
+    }
+  },
+  {
+    "id": "019a0ec1-e54d-7354-be40-62fb6f0e5d43",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-5-medium",
+    "name": "gpt-5-medium",
+    "displayName": "gpt-5-medium",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 35,
+    "rankByModality": {
+      "webdev": 35
+    }
+  },
+  {
+    "id": "019a95f0-02c7-7f62-a820-c809f767a222",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "gpt-5.1-medium",
+    "name": "gpt-5.1-medium",
+    "displayName": "gpt-5.1-medium",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 37,
+    "rankByModality": {
+      "webdev": 37
+    }
+  },
+  {
+    "id": "019c9270-c586-73c6-b2d9-673d5ec2e1d4",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3.5-122b-a10b-code",
+    "name": "qwen3.5-122b-a10b-code",
+    "displayName": "qwen3.5-122b-a10b-code",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 50,
+    "rankByModality": {
+      "webdev": 50
+    }
+  },
+  {
+    "id": "019c9241-3e5a-7ab0-8c94-5d3b7c6dafad",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3.5-27b-code",
+    "name": "qwen3.5-27b-code",
+    "displayName": "qwen3.5-27b-code",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 52,
+    "rankByModality": {
+      "webdev": 52
+    }
+  },
+  {
+    "id": "019bbe75-406e-73de-8eeb-b2a60457cdf6",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.2-codex",
+    "name": "gpt-5.2-codex",
+    "displayName": "gpt-5.2-codex",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 56,
+    "rankByModality": {
+      "webdev": 56
+    }
+  },
+  {
+    "id": "019a84e2-e1b7-718b-8b8d-589079121b9b",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.1-codex",
+    "name": "gpt-5.1-codex",
+    "displayName": "gpt-5.1-codex",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 59,
+    "rankByModality": {
+      "webdev": 59
+    }
+  },
+  {
+    "id": "019c030b-d0ae-7849-9fa4-8730f05aaaa3",
+    "organization": "kwai",
+    "provider": "kwai",
+    "publicName": "KAT-Coder-Pro-V1",
+    "name": "KAT-Coder-Pro-V1-unlimited-20260127",
+    "displayName": "KAT-Coder-Pro-V1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 65,
+    "rankByModality": {
+      "webdev": 65
+    }
+  },
+  {
+    "id": "019c9254-fda3-7824-bcf3-b4bac91bc094",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3.5-35b-a3b-code",
+    "name": "qwen3.5-35b-a3b-code",
+    "displayName": "qwen3.5-35b-a3b-code",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 66,
+    "rankByModality": {
+      "webdev": 66
+    }
+  },
+  {
+    "id": "019a84e2-e6bd-7123-a5f6-626d1766d4f2",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.1-codex-mini",
+    "name": "gpt-5.1-codex-mini",
+    "displayName": "gpt-5.1-codex-mini",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 69,
+    "rankByModality": {
+      "webdev": 69
+    }
+  },
+  {
+    "id": "019be7bf-bd7e-74d3-97ee-674fe4d9d8a9",
+    "organization": "mistral",
+    "provider": "mistral",
+    "publicName": "devstral-2",
+    "name": "devstral-2",
+    "displayName": "devstral-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 76,
+    "rankByModality": {
+      "webdev": 76
+    }
+  },
+  {
+    "id": "019a6a30-cd7d-7431-8c4a-7be88deebf43",
+    "organization": "mistral",
+    "provider": "mistral",
+    "publicName": "devstral-medium-2507",
+    "name": "devstral-medium-2507",
+    "displayName": "devstral-medium-2507",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 80,
+    "rankByModality": {
+      "webdev": 80
+    }
+  },
+  {
+    "id": "019d4d43-7066-7f2e-8e0c-8ebbe2de560c",
+    "publicName": "gallant",
+    "displayName": "gallant",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019dda8f-d4c4-7466-9093-5094edee586d",
+    "publicName": "vero-noesis",
+    "displayName": "vero-noesis",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019de6ed-097f-7b47-8093-37e3f4a49f43",
+    "publicName": "kartoffeln",
+    "displayName": "kartoffeln",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019c8e68-2623-7228-bdfd-0284ed5144be",
+    "publicName": "dove",
+    "displayName": "dove",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019abd9a-f6ff-7081-8bdb-ff0a352dc601",
+    "publicName": "robin",
+    "displayName": "robin",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019c490c-bf30-7a8c-9eba-479f3710f261",
+    "publicName": "dart-frog-0206",
+    "displayName": "dart-frog-0206",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d4d43-09d6-7f53-adb0-b1b011cb2a4e",
+    "publicName": "vulcan",
+    "displayName": "vulcan",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019e2230-4a6d-7d5f-b066-d081ed2c08d2",
+    "publicName": "kiravel",
+    "displayName": "kiravel",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019ac30c-70ce-72af-b6e9-cfbc52d46c19",
+    "publicName": "robin-high",
+    "displayName": "robin-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019e3462-1988-71f0-a741-1d7c909650d2",
+    "publicName": "gemini-3.1-pro",
+    "displayName": "gemini-3.1-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019e271b-447e-7a6e-bcb7-c7f982b130b2",
+    "publicName": "may-alpha",
+    "displayName": "may-alpha",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019e3bbb-ef47-761f-a297-dd85b6280e6f",
+    "publicName": "kymir",
+    "displayName": "kymir",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019cc0bb-af26-70d6-9271-ec771d778174",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.4-high",
+    "name": "gpt-5.4-high-code-arena-harness",
+    "displayName": "gpt-5.4-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": false,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019cdb71-ad5f-7caa-af3e-a705555e0937",
+    "publicName": "jester",
+    "displayName": "jester",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d3c9d-31cb-7261-89a4-bf352c152d31",
+    "publicName": "juniper",
+    "displayName": "juniper",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019ce35b-20d0-7ff9-b788-19c010555fc5",
+    "organization": "xai",
+    "provider": "xaiApi",
+    "publicName": "grok-4.20-beta-0309-reasoning",
+    "name": "grok-4.20-beta-0309-reasoning-code",
+    "displayName": "grok-4.20-beta-0309-reasoning",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d7b56-f238-7bf1-b228-43fa9ea330e9",
+    "publicName": "sphinx",
+    "displayName": "sphinx",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d561b-9c05-7a00-a729-e606dac1c4df",
+    "publicName": "vulcan",
+    "displayName": "vulcan",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019c6553-77c6-7363-966a-e4292cdcaabc",
+    "publicName": "star-drift",
+    "displayName": "star-drift",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d2cf9-a55b-7d78-abe0-f4d5dc87a3b7",
+    "publicName": "emu",
+    "displayName": "emu",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d561b-6cfc-720b-b986-dbd56eb25732",
+    "publicName": "gallant",
+    "displayName": "gallant",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d3341-6887-7ce2-ab74-756d752ef380",
+    "publicName": "pepper",
+    "displayName": "pepper",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019cc0bb-5d0f-71bc-9aa3-d8fc64b8968d",
+    "publicName": "gpt-5.4",
+    "displayName": "gpt-5.4",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019da1dc-d2f8-758b-a1d7-9f82cbae77f0",
+    "publicName": "kiwire",
+    "displayName": "kiwire",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019cc0bc-4474-79fa-89f7-1923dea80521",
+    "publicName": "gpt-5.4",
+    "displayName": "gpt-5.4",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019cc0bc-202f-76cb-9767-01687018a6b7",
+    "publicName": "gpt-5.4-medium",
+    "displayName": "gpt-5.4-medium",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019cf062-9465-71de-9bb5-19ead2a9fc2d",
+    "publicName": "spire",
+    "displayName": "spire",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d6e0b-72a1-7fed-9395-17622781e7e2",
+    "publicName": "zorik",
+    "displayName": "zorik",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019cc0ba-d215-79b9-b55a-f4b06876238b",
+    "publicName": "gpt-5.2-high",
+    "displayName": "gpt-5.2-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019c00e2-8c86-7a1f-8712-35979d27027c",
+    "publicName": "alligator",
+    "displayName": "alligator",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019cc0bb-f834-7162-a5c1-05c623b89c20",
+    "publicName": "gpt-5.4-high",
+    "displayName": "gpt-5.4-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019c2258-b6d1-7a61-890f-5f3f11e7c3b1",
+    "publicName": "badger",
+    "displayName": "badger",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019c48f7-653b-74c2-9036-d2e2f321ca46",
+    "publicName": "pine",
+    "displayName": "pine",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019c4901-a133-75a6-bf06-0e6eba27b195",
+    "publicName": "chipmunk",
+    "displayName": "chipmunk",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019dd034-9da3-772b-9589-dbcaca8b9dc5",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.5-xhigh",
+    "name": "gpt-5.5-xhigh-code-codex-harness",
+    "displayName": "gpt-5.5-xhigh",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": false,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d4ec3-b69b-724b-9c43-4e7c6125dcbb",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3.6-plus-preview",
+    "name": "qwen3.6-plus-preview",
+    "displayName": "qwen3.6-plus-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019e0952-6f72-7cc8-b379-5daf72b6cddc",
+    "publicName": "solar-pro-3",
+    "displayName": "solar-pro-3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc0ba-0c5d-74cb-8bf2-096f460eadab",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.5-high",
+    "name": "gpt-5.5-high-code-codex-harness",
+    "displayName": "gpt-5.5-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": false,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019c1b89-cd55-7d2f-8a69-4da2372dbc41",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3-max-thinking",
+    "name": "qwen3-max-thinking-webdev",
+    "displayName": "qwen3-max-thinking",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019e36c3-691f-7ae8-b1eb-5db5435e29fe",
+    "publicName": "korin",
+    "displayName": "korin",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019df3d8-017b-7f1a-bd76-b1882d21654f",
+    "publicName": "kavel",
+    "displayName": "kavel",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019bec66-03fe-7c18-8ee1-9c1414762f99",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.2-high",
+    "name": "gpt-5.2-high-code-20260122",
+    "displayName": "gpt-5.2-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019dac5a-88e0-7477-b100-336eaf25c4b6",
+    "organization": "moonshot",
+    "provider": "moonshot",
+    "publicName": "kimi-k2.6",
+    "name": "kimi-k2.6-code",
+    "displayName": "kimi-k2.6",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019dd9d9-db98-79f7-825c-0fdf686e9705",
+    "organization": "poolside",
+    "provider": "poolsideProd",
+    "publicName": "laguna-m.1",
+    "name": "laguna-m.1",
+    "displayName": "laguna-m.1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019dd9da-23c2-7aca-9691-4d33823db8eb",
+    "organization": "poolside",
+    "provider": "poolsideProd",
+    "publicName": "laguna-xs.2",
+    "name": "laguna-xs.2",
+    "displayName": "laguna-xs.2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc0bb-ab8d-77bb-8315-424fc805b625",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.5",
+    "name": "gpt-5.5-code-codex-harness",
+    "displayName": "gpt-5.5",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": false,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019d50a9-ff12-7beb-b423-0b4904415f39",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen3.6-plus",
+    "name": "qwen3.6-plus",
+    "displayName": "qwen3.6-plus",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019dd7a4-f384-79f0-aa10-c91147438642",
+    "organization": "alibaba",
+    "provider": "alibabaToolCall",
+    "publicName": "qwen3.6-max-preview",
+    "name": "qwen3.6-max-preview-code",
+    "displayName": "qwen3.6-max-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019bec65-0700-7279-911b-34e6aab53ad6",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.2",
+    "name": "gpt-5.2-code-20260122",
+    "displayName": "gpt-5.2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019aeb38-cc3b-7421-a472-0bfaaeace035",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.1-codex-max",
+    "name": "gpt-5.1-codex-max",
+    "displayName": "gpt-5.1-codex-max",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019cc0bb-8758-7a5c-897d-7baf199c6c49",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.4-medium",
+    "name": "gpt-5.4-medium-code-arena-harness",
+    "displayName": "gpt-5.4-medium",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "web": true
+      }
+    },
+    "userSelectable": false,
+    "rankByModality": {
+      "webdev": 9007199254740991
+    }
+  },
+  {
+    "id": "019cc5af-99e4-77d0-9331-5a49748100a1",
+    "organization": "google",
+    "provider": "google-genai",
+    "publicName": "gemini-3.1-flash-image-preview (nano-banana-2) [web-search]",
+    "name": "gemini-3.1-flash-image-preview (nano-banana-2)",
+    "displayName": "gemini-3.1-flash-image-preview (nano-banana-2) [web-search]",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 2,
+    "rankByModality": {
+      "image": 2
+    }
+  },
+  {
+    "id": "019be243-f89b-76a4-943d-553f46f62993",
+    "organization": "openai",
+    "provider": "customOpenai",
+    "publicName": "gpt-image-1.5-high-fidelity",
+    "name": "gpt-image-1.5-high-fidelity",
+    "displayName": "gpt-image-1.5-high-fidelity",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 4,
+    "rankByModality": {
+      "image": 4
+    }
+  },
+  {
+    "id": "019abc10-e78d-7932-b725-7f1563ed8a12",
+    "organization": "google",
+    "provider": "google-genai",
+    "publicName": "gemini-3-pro-image-preview-2k (nano-banana-pro)",
+    "name": "gemini-3-pro-image-preview-2k",
+    "displayName": "gemini-3-pro-image-preview-2k (nano-banana-pro)",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 5,
+    "rankByModality": {
+      "image": 5
+    }
+  },
+  {
+    "id": "019cea29-a9eb-7e5c-8724-48cac44b18e3",
+    "organization": "microsoft-ai",
+    "provider": "maiImage",
+    "publicName": "tatertot",
+    "name": "tatertot",
+    "displayName": "mai-image-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 9,
+    "rankByModality": {
+      "image": 9
+    }
+  },
+  {
+    "id": "019d9da0-9b76-7b88-a626-8a1de9bee9cc",
+    "organization": "alibaba",
+    "provider": "qwenImage",
+    "publicName": "autobear",
+    "name": "autobear",
+    "displayName": "qwen-image-2.0-pro-2026-04-22",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 11,
+    "rankByModality": {
+      "image": 11
+    }
+  },
+  {
+    "id": "019c8114-8ab7-7619-b16e-eddbe191b59a",
+    "organization": "reve",
+    "provider": "reve",
+    "publicName": "left-bank",
+    "name": "left-bank",
+    "displayName": "reve-v1.5",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 12,
+    "rankByModality": {
+      "image": 12
+    }
+  },
+  {
+    "id": "019b478d-71ee-7658-867a-bce80c8e77a3",
+    "organization": "bfl",
+    "provider": "bfl",
+    "publicName": "flux-2-max",
+    "name": "flux-2-max-20251222",
+    "displayName": "flux-2-max",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 13,
+    "rankByModality": {
+      "image": 13
+    }
+  },
+  {
+    "id": "019b7541-5e4b-7ff7-a34b-b0255b6ca9aa",
+    "organization": "bfl",
+    "provider": "bfl",
+    "publicName": "flux-2-pro",
+    "name": "flux-2-pro-20251231",
+    "displayName": "flux-2-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 15,
+    "rankByModality": {
+      "image": 15
+    }
+  },
+  {
+    "id": "019c0a72-54f1-7c85-8475-3ee4a79bcc5f",
+    "organization": "bfl",
+    "provider": "bfl",
+    "publicName": "flux-2-flex",
+    "name": "flux-2-flex-20260129",
+    "displayName": "flux-2-flex",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 16,
+    "rankByModality": {
+      "image": 16
+    }
+  },
+  {
+    "id": "7766a45c-1b6b-4fb8-9823-2557291e1ddd",
+    "organization": "tencent",
+    "provider": "tencent",
+    "publicName": "hunyuan-image-3.0",
+    "name": "hunyuan-image-3.0",
+    "displayName": "hunyuan-image-3.0",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 18,
+    "rankByModality": {
+      "image": 18
+    }
+  },
+  {
+    "id": "019b478d-74ae-7d19-9a8f-6cfde89ab4ca",
+    "organization": "bfl",
+    "provider": "bfl",
+    "publicName": "flux-2-dev",
+    "name": "flux-2-dev-20251222",
+    "displayName": "flux-2-dev",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 19,
+    "rankByModality": {
+      "image": 19
+    }
+  },
+  {
+    "id": "019b3943-7503-776f-9632-c3c5da0c39b7",
+    "organization": "bytedance",
+    "provider": "byteplus",
+    "publicName": "seedream-4.5",
+    "name": "autumn-byteplus",
+    "displayName": "seedream-4.5",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 21,
+    "rankByModality": {
+      "image": 21
+    }
+  },
+  {
+    "id": "019ae6da-6788-761a-8253-e0bb2bf2e3a9",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "imagen-4.0-generate-001",
+    "name": "imagen-4.0-generate-001",
+    "displayName": "imagen-4.0-generate-001",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 24,
+    "rankByModality": {
+      "image": 24
+    }
+  },
+  {
+    "id": "019b8194-58e4-7975-ad6b-d966909a0eb8",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen-image-2512",
+    "name": "qwen-image-2512",
+    "displayName": "qwen-image-2512",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 25,
+    "rankByModality": {
+      "image": 25
+    }
+  },
+  {
+    "id": "019c9078-386f-7c92-99f3-97d5d6b0f239",
+    "organization": "bytedance",
+    "provider": "byteplus",
+    "publicName": "seedream-5.0-lite",
+    "name": "seedream-5.0-lite",
+    "displayName": "seedream-5.0-lite",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 26,
+    "rankByModality": {
+      "image": 26
+    }
+  },
+  {
+    "id": "019a5050-1695-7b5d-b045-ba01ff08ec28",
+    "publicName": "wan2.5-preview",
+    "displayName": "wan2.5-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 28,
+    "rankByModality": {
+      "image": 28
+    }
+  },
+  {
+    "id": "019a5050-2875-78ed-ae3a-d9a51a438685",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "wan2.5-t2i-preview",
+    "name": "wan2.5-t2i-preview",
+    "displayName": "wan2.5-t2i-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 28,
+    "rankByModality": {
+      "image": 28
+    }
+  },
+  {
+    "id": "69f90b32-01dc-43e1-8c48-bf494f8f4f38",
+    "publicName": "gpt-image-1-high-fidelity",
+    "displayName": "gpt-image-1-high-fidelity",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 30,
+    "rankByModality": {
+      "image": 30
+    }
+  },
+  {
+    "id": "6e855f13-55d7-4127-8656-9168a9f4dcc0",
+    "organization": "openai",
+    "provider": "customOpenai",
+    "publicName": "gpt-image-1",
+    "name": "gpt-image-1",
+    "displayName": "gpt-image-1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 30,
+    "rankByModality": {
+      "image": 30
+    }
+  },
+  {
+    "id": "32974d8d-333c-4d2e-abf3-f258c0ac1310",
+    "organization": "bytedance",
+    "provider": "fal",
+    "publicName": "seedream-4-high-res-fal",
+    "name": "seedream-4-high-res-fal",
+    "displayName": "seedream-4-high-res-fal",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 31,
+    "rankByModality": {
+      "image": 31
+    }
+  },
+  {
+    "id": "019c6e76-a7c0-7b05-8dce-bbe3d52c8f4e",
+    "organization": "Recraft",
+    "provider": "fal",
+    "publicName": "recraft-v4",
+    "name": "recraft-v4",
+    "displayName": "recraft-v4",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 32,
+    "rankByModality": {
+      "image": 32
+    }
+  },
+  {
+    "id": "0199c238-f8ee-7f7d-afc1-7e28fcfd21cf",
+    "organization": "openai",
+    "provider": "customOpenai",
+    "publicName": "gpt-image-1-mini",
+    "name": "gpt-image-1-mini",
+    "displayName": "gpt-image-1-mini",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 33,
+    "rankByModality": {
+      "image": 33
+    }
+  },
+  {
+    "id": "019db3f0-b024-7478-bd4d-55ea1ec1d421",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "wan2.7-image-pro",
+    "name": "wan2.7-image-pro-0421",
+    "displayName": "wan2.7-image-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 34,
+    "rankByModality": {
+      "image": 34
+    }
+  },
+  {
+    "id": "019db3ef-f2e3-7508-b3bc-c2ba377804ea",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "wan2.7-image",
+    "name": "wan2.7-image-0421",
+    "displayName": "wan2.7-image",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 35,
+    "rankByModality": {
+      "image": 35
+    }
+  },
+  {
+    "id": "019b4782-79d7-721c-a56c-6bb09bc3a437",
+    "publicName": "z-image",
+    "displayName": "z-image",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 37,
+    "rankByModality": {
+      "image": 37
+    }
+  },
+  {
+    "id": "d8771262-8248-4372-90d5-eb41910db034",
+    "organization": "bytedance",
+    "provider": "fal",
+    "publicName": "seedream-3",
+    "name": "seedream-3",
+    "displayName": "seedream-3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 38,
+    "rankByModality": {
+      "image": 38
+    }
+  },
+  {
+    "id": "0633b1ef-289f-49d4-a834-3d475a25e46b",
+    "publicName": "flux-1-kontext-max",
+    "displayName": "flux-1-kontext-max",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 39,
+    "rankByModality": {
+      "image": 39
+    }
+  },
+  {
+    "id": "019bc2a5-1f01-719e-9eb2-cc47320d0406",
+    "organization": "bfl",
+    "provider": "bfl",
+    "publicName": "flux-2-klein-9b",
+    "name": "flux-2-klein-9b",
+    "displayName": "flux-2-klein-9b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 40,
+    "rankByModality": {
+      "image": 40
+    }
+  },
+  {
+    "id": "9fe82ee1-c84f-417f-b0e7-cab4ae4cf3f3",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen-image-prompt-extend",
+    "name": "qwen-image-prompt-extend",
+    "displayName": "qwen-image-prompt-extend",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 41,
+    "rankByModality": {
+      "image": 41
+    }
+  },
+  {
+    "id": "28a8f330-3554-448c-9f32-2c0a08ec6477",
+    "organization": "bfl",
+    "provider": "bfl",
+    "publicName": "flux-1-kontext-pro",
+    "name": "flux-1-kontext-pro",
+    "displayName": "flux-1-kontext-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 42,
+    "rankByModality": {
+      "image": 42
+    }
+  },
+  {
+    "id": "51ad1d79-61e2-414c-99e3-faeb64bb6b1b",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "imagen-3.0-generate-002",
+    "name": "imagen-3.0-generate-002",
+    "displayName": "imagen-3.0-generate-002",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 43,
+    "rankByModality": {
+      "image": 43
+    }
+  },
+  {
+    "id": "73378be5-cdba-49e7-b3d0-027949871aa6",
+    "organization": "Ideogram",
+    "provider": "fal",
+    "publicName": "ideogram-v3-quality",
+    "name": "ideogram-v3-quality",
+    "displayName": "ideogram-v3-quality",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 45,
+    "rankByModality": {
+      "image": 45
+    }
+  },
+  {
+    "id": "e7c9fa2d-6f5d-40eb-8305-0980b11c7cab",
+    "organization": "luma-ai",
+    "provider": "fal",
+    "publicName": "photon",
+    "name": "photon",
+    "displayName": "photon",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 46,
+    "rankByModality": {
+      "image": 46
+    }
+  },
+  {
+    "id": "019be7ac-c5bd-7852-8d6b-b071089ce0cd",
+    "organization": "pruna",
+    "provider": "pruna",
+    "publicName": "p-image",
+    "name": "p-image",
+    "displayName": "p-image",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 47,
+    "rankByModality": {
+      "image": 47
+    }
+  },
+  {
+    "id": "019bc2a5-76d9-7a25-8ee9-f68a96df2340",
+    "organization": "bfl",
+    "provider": "bfl",
+    "publicName": "flux-2-klein-4b",
+    "name": "flux-2-klein-4b",
+    "displayName": "flux-2-klein-4b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 48,
+    "rankByModality": {
+      "image": 48
+    }
+  },
+  {
+    "id": "019ce84a-d311-7fb0-b58b-713e43dea909",
+    "organization": "runway",
+    "provider": "replicate",
+    "publicName": "runway-gen4",
+    "name": "runway-gen4-text-to-image",
+    "displayName": "runway-gen4",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 49,
+    "rankByModality": {
+      "image": 49
+    }
+  },
+  {
+    "id": "b88d5814-1d20-49cc-9eb6-e362f5851661",
+    "organization": "Recraft",
+    "provider": "fal",
+    "publicName": "recraft-v3",
+    "name": "recraft-v3",
+    "displayName": "recraft-v3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 50,
+    "rankByModality": {
+      "image": 50
+    }
+  },
+  {
+    "id": "5a3b3520-c87d-481f-953c-1364687b6e8f",
+    "organization": "leonardo-ai",
+    "provider": "leonardo-ai",
+    "publicName": "lucid-origin",
+    "name": "lucid-origin",
+    "displayName": "lucid-origin",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 53,
+    "rankByModality": {
+      "image": 53
+    }
+  },
+  {
+    "id": "eb90ae46-a73a-4f27-be8b-40f090592c9a",
+    "organization": "bfl",
+    "provider": "bfl",
+    "publicName": "flux-1-kontext-dev",
+    "name": "flux-1-kontext-dev",
+    "displayName": "flux-1-kontext-dev",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rank": 58,
+    "rankByModality": {
+      "image": 58
+    }
+  },
+  {
+    "id": "019dd7b9-334b-7b02-b57f-b54bc35931c8",
+    "publicName": "harbor",
+    "displayName": "harbor",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019de640-b136-7b8b-98bd-8eb03f5d4649",
+    "organization": "openai",
+    "publicName": "gpt-image-2 (medium)",
+    "displayName": "gpt-image-2 (medium)",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019dd7ba-5ea2-74ec-9488-c068b8e88b2d",
+    "publicName": "thunder",
+    "displayName": "thunder",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019d8e61-b2a7-750f-a1e3-685bc7ff14ba",
+    "publicName": "flow-state",
+    "displayName": "flow-state",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019c45d5-00a7-7c59-92e2-856f7e9f86b0",
+    "publicName": "citrus",
+    "displayName": "citrus",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc168-0c71-7b73-9b5c-7945d00f7a7f",
+    "publicName": "flow-state-2",
+    "displayName": "flow-state-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019dc16f-de2e-7b18-91bb-9acefd32c935",
+    "publicName": "flow-state-3",
+    "displayName": "flow-state-3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e1ccf-1b4c-7248-9a4f-c0f7a86279b9",
+    "publicName": "greenbean",
+    "displayName": "greenbean",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019cfdba-8650-74a0-af6f-1ff2ebbb64da",
+    "publicName": "waffle",
+    "displayName": "waffle",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e373c-3320-7295-ad71-d73cf7248b53",
+    "publicName": "flashfennel",
+    "displayName": "flashfennel",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019cb611-a2cb-7b3c-83e0-573644a80f75",
+    "publicName": "pebble-1",
+    "displayName": "pebble-1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019cb611-cccc-779f-979f-56bc9417f9ef",
+    "publicName": "pebble-2",
+    "displayName": "pebble-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e1cd7-5cc5-75d2-8b3e-275616dec624",
+    "publicName": "hidream-o1-image",
+    "displayName": "hidream-o1-image",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019cb612-06cc-73c0-9120-40cd75433322",
+    "publicName": "pebble-2",
+    "displayName": "pebble-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019cb612-2486-7498-ab79-eb9dddfe3def",
+    "publicName": "pebble-1",
+    "displayName": "pebble-1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019be7ac-e2d9-7d8d-975c-225fafbe6940",
+    "organization": "pruna",
+    "provider": "pruna",
+    "publicName": "p-image-edit",
+    "name": "p-image-edit",
+    "displayName": "p-image-edit",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "32bff2df-00e6-409b-ad3f-bfbad87cc49f",
+    "publicName": "hidream-e1.1",
+    "displayName": "hidream-e1.1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "995cf221-af30-466d-a809-8e0985f83649",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen-image-edit",
+    "name": "qwen-image-edit",
+    "displayName": "qwen-image-edit",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019c5501-cf4a-7320-b1c0-407bfaf0a65a",
+    "publicName": "gcps-fast",
+    "displayName": "gcps-fast",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019d287c-4906-7f9c-8b78-8a2a86cf00a5",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen-image-2.0",
+    "name": "qwen-image-2.0-2026-03-03-v3",
+    "displayName": "qwen-image-2.0",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019d287b-b718-7daa-ad65-502596d0813d",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen-image-2.0-pro",
+    "name": "qwen-image-2.0-pro-2026-03-03-v3",
+    "displayName": "qwen-image-2.0-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019d69fe-b55c-7af8-94a2-199997d66666",
+    "publicName": "flashbrown-a",
+    "displayName": "flashbrown-a",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "0199e980-d247-7dd3-9ca1-77092f126f05",
+    "publicName": "hunyuan-image-3.0-fal",
+    "displayName": "hunyuan-image-3.0-fal",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019d04e2-2236-7e5b-ab40-74d105a534d2",
+    "publicName": "gallery",
+    "displayName": "gallery",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019cc6e2-6e4a-76c1-bf57-76b12d98dbf3",
+    "organization": "xai",
+    "provider": "xaiImage",
+    "publicName": "grok-imagine-image",
+    "name": "grok-imagine-image-20260306",
+    "displayName": "grok-imagine-image",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019d4002-95d4-7b0e-accb-0d0d2f263cc5",
+    "publicName": "soft-shell",
+    "displayName": "soft-shell",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019d69fe-e309-7d4d-aa34-cd550fe3597f",
+    "publicName": "flashbrown-b",
+    "displayName": "flashbrown-b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019c2473-76cc-76a0-a73d-3393599366ed",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "wan2.6-t2i",
+    "name": "wan2.6-t2i-v2",
+    "displayName": "wan2.6-t2i",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019cea29-dee1-72ca-8305-126c9da0ff9f",
+    "publicName": "chives",
+    "displayName": "chives",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019d9f72-9c6e-7018-a695-6c5547165845",
+    "publicName": "flow-state",
+    "displayName": "flow-state",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019df63c-2b82-7806-96d6-4aac698324b6",
+    "publicName": "fennel",
+    "displayName": "fennel",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019c0dbe-439d-7074-a477-be0a0ee43537",
+    "publicName": "super-cara",
+    "displayName": "super-cara",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019db1cb-1bc1-774a-9bb2-376e74c0c97e",
+    "publicName": "frenchfry",
+    "displayName": "frenchfry",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019bec2d-e92c-745d-ae46-c7166590237a",
+    "organization": "tencent",
+    "provider": "tencentEval",
+    "publicName": "sungod",
+    "name": "hunyuan-image-3.0-i2i",
+    "displayName": "hunyuan-image-3.0-instruct",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019c16b6-be54-7d49-b6fb-9e30892c2288",
+    "publicName": "super-gcp",
+    "displayName": "super-gcp",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e3ca2-4821-7ef9-af5a-f202338c29de",
+    "publicName": "zen-bear",
+    "displayName": "zen-bear",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019db1cb-7b41-7da2-8672-7c62539ada22",
+    "publicName": "shakshouka",
+    "displayName": "shakshouka",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e3190-23fc-73c0-acf4-0d586db22e8d",
+    "publicName": "albertosaurus",
+    "displayName": "albertosaurus",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e3195-7a3b-762f-a45a-81dc37214b86",
+    "publicName": "ellsworth",
+    "displayName": "ellsworth",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "e2969ebb-6450-4bc4-87c9-bbdcf95840da",
+    "organization": "bytedance",
+    "provider": "fal",
+    "publicName": "seededit-3.0",
+    "name": "seededit-3.0",
+    "displayName": "seededit-3.0",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019c3438-bddf-7e38-822c-9aeb0789f1fd",
+    "publicName": "kling-image-o1",
+    "displayName": "kling-image-o1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019d977a-cec2-720f-9b49-b378ebdd0ab8",
+    "publicName": "dialogue",
+    "displayName": "dialogue",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019dea47-b63e-7881-a1c3-375a89709664",
+    "organization": "luma-ai",
+    "provider": "lumaImage",
+    "publicName": "flow-state-5",
+    "name": "flow-state-5-1y1p",
+    "displayName": "uni-1.1-max",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019b169a-09c6-79ea-9400-1566d793ade1",
+    "organization": "reve",
+    "provider": "reve",
+    "publicName": "reve-v1.1",
+    "name": "epsilon",
+    "displayName": "reve-v1.1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "0199ef2a-583f-7088-b704-b75fd169401d",
+    "organization": "google",
+    "provider": "google-genai",
+    "publicName": "gemini-2.5-flash-image-preview (nano-banana)",
+    "name": "gemini-2.5-flash-image-preview (nano-banana)",
+    "displayName": "gemini-2.5-flash-image-preview (nano-banana)",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "a9a26426-5377-4efa-bef9-de71e29ad943",
+    "organization": "tencent",
+    "provider": "fal",
+    "publicName": "hunyuan-image-2.1",
+    "name": "hunyuan-image-2.1",
+    "displayName": "hunyuan-image-2.1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019dbb6f-f0fe-7ecd-9007-46859df360f7",
+    "publicName": "paper-lantern",
+    "displayName": "paper-lantern",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e3eb6-0c90-721b-bc36-a97d280b8262",
+    "publicName": "allosaurus",
+    "displayName": "allosaurus",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019dd068-9595-7b76-8228-9c1f41ab7897",
+    "publicName": "crepe",
+    "displayName": "crepe",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019db344-75b0-7acd-aa20-bcc095ca0ed9",
+    "organization": "openai",
+    "provider": "customOpenai",
+    "publicName": "gpt-image-2 (medium)",
+    "name": "gpt-image-2-medium",
+    "displayName": "gpt-image-2 (medium)",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e24bc-ba1d-7809-baa9-cbde3b575acb",
+    "publicName": "recraft-v4.1",
+    "displayName": "recraft-v4.1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e24be-1462-72f5-9d42-2b6a40b8b2f3",
+    "publicName": "recraft-v4.1-utility",
+    "displayName": "recraft-v4.1-utility",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019ae6da-6438-7077-9d2d-b311a35645f8",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "imagen-4.0-ultra-generate-001",
+    "name": "imagen-4.0-ultra-generate-001",
+    "displayName": "imagen-4.0-ultra-generate-001",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e4218-8a5b-7622-9b37-3d5d9effa3ba",
+    "publicName": "ellsworth",
+    "displayName": "ellsworth",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e4271-4717-7dd9-a0e2-90783fbabd25",
+    "publicName": "blue-crab",
+    "displayName": "blue-crab",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e0e7d-c675-76ea-864e-f73d1086e685",
+    "publicName": "fennelbaby",
+    "displayName": "fennelbaby",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019b8194-804a-775d-86d4-c8ded9ba3e9f",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "qwen-image-edit-2511",
+    "name": "qwen-image-edit-2511",
+    "displayName": "qwen-image-edit-2511",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e0b3a-5f5b-745c-9416-094799115a1f",
+    "publicName": "archaeopteryx",
+    "displayName": "archaeopteryx",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019b207a-d836-7742-a312-b2b247b2366e",
+    "organization": "reve",
+    "provider": "fal",
+    "publicName": "reve-v1.1-fast",
+    "name": "epsilon-fast",
+    "displayName": "reve-v1.1-fast",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019de0fc-472b-77e9-b15a-34aa2868f825",
+    "publicName": "flow-state-2",
+    "displayName": "flow-state-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019de0fc-7480-78b1-b6a0-f5d2adf478b5",
+    "publicName": "flow-state-3",
+    "displayName": "flow-state-3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019aeb62-c6ea-788e-88f9-19b1b48325b5",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "wan2.5-i2i-preview",
+    "name": "wan2.5-i2i-preview",
+    "displayName": "wan2.5-i2i-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e2e45-8f31-7ae2-ba00-214711bc2a1e",
+    "organization": "xai",
+    "provider": "xaiImage",
+    "publicName": "grok-imagine-image-quality",
+    "name": "grok-imagine-image-quality",
+    "displayName": "grok-imagine-image-quality",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019adb32-afa4-749e-9992-39653b52fe13",
+    "organization": "shengshu",
+    "provider": "shengshu",
+    "publicName": "vidu-q2-image",
+    "name": "viduq2-image",
+    "displayName": "vidu-q2-image",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": false
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019dd579-7ee0-7ef9-9a01-2cc76f59b2a1",
+    "publicName": "flow-state-3",
+    "displayName": "flow-state-3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019dd579-4fc3-76a7-8ed8-ef12d7f1a48d",
+    "publicName": "flow-state-2",
+    "displayName": "flow-state-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019d2c92-5c4d-7b5f-8eda-b45f179e6444",
+    "organization": "kling",
+    "provider": "fal",
+    "publicName": "kling-image-o1",
+    "name": "kling-image-o1-fal",
+    "displayName": "kling-image-o1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019e1d88-45c1-7d54-aa6b-ccd1c8cbb409",
+    "publicName": "dimetrodon",
+    "displayName": "dimetrodon",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019dea47-ffb0-7023-ab1a-fc91f37a70ef",
+    "organization": "luma-ai",
+    "provider": "lumaImage",
+    "publicName": "flow-state-4",
+    "name": "flow-state-4-b1my",
+    "displayName": "uni-1.1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019dfec5-a13a-7e56-af8f-b40ab392c88e",
+    "publicName": "mondrian",
+    "displayName": "mondrian",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "f44fd4f8-af30-480f-8ce2-80b2bdfea55e",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "imagen-4.0-fast-generate-001",
+    "name": "imagen-4.0-fast-generate-001",
+    "displayName": "imagen-4.0-fast-generate-001",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019be242-8366-7a60-a378-160b233d1f76",
+    "organization": "openai",
+    "provider": "customOpenai",
+    "publicName": "chatgpt-image-latest-high-fidelity (20251216)",
+    "name": "chatgpt-image-latest-high-fidelity-20251216",
+    "displayName": "chatgpt-image-latest-high-fidelity (20251216)",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019bece2-d22d-7d91-8cc6-1d4ba4a35bbb",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "wan2.6-image",
+    "name": "wan2.6-image",
+    "displayName": "wan2.6-image",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true,
+          "multipleImages": true
+        }
+      },
+      "outputCapabilities": {
+        "image": {
+          "aspectRatios": [
+            "1:1"
+          ]
+        }
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "image": 9007199254740991
+    }
+  },
+  {
+    "id": "019c6f55-308b-71ac-95af-f023a48253cf",
+    "organization": "anthropic",
+    "provider": "anthropicSearch",
+    "publicName": "claude-opus-4-6-search",
+    "name": "claude-opus-4-6-search",
+    "displayName": "claude-opus-4-6-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 1,
+    "rankByModality": {
+      "search": 1
+    }
+  },
+  {
+    "id": "019dc0ba-5395-7db4-9731-472e97acf221",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.5-search",
+    "name": "gpt-5.5-search",
+    "displayName": "gpt-5.5-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 2,
+    "rankByModality": {
+      "search": 2
+    }
+  },
+  {
+    "id": "019dc1ff-c88d-7106-bba7-b2358c26c590",
+    "organization": "anthropic",
+    "provider": "anthropicSearch",
+    "publicName": "claude-opus-4-7-search",
+    "name": "claude-opus-4-7-search",
+    "displayName": "claude-opus-4-7-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 3,
+    "rankByModality": {
+      "search": 3
+    }
+  },
+  {
+    "id": "019dda73-94e9-714b-a97e-aafd10732571",
+    "organization": "baidu",
+    "provider": "baiduyiyanSearch",
+    "publicName": "stellar-harbor",
+    "name": "stellar-harbor",
+    "displayName": "ernie-5.1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 4,
+    "rankByModality": {
+      "search": 4
+    }
+  },
+  {
+    "id": "019c6f55-70d6-7a9c-b89b-9a0db36a3582",
+    "organization": "anthropic",
+    "provider": "anthropicSearch",
+    "publicName": "claude-sonnet-4-6-search",
+    "name": "claude-sonnet-4-6-search",
+    "displayName": "claude-sonnet-4-6-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 5,
+    "rankByModality": {
+      "search": 5
+    }
+  },
+  {
+    "id": "019ce84a-f675-780c-a2bb-f86498a34de5",
+    "organization": "google",
+    "provider": "googleVertexGlobalSearch",
+    "publicName": "gemini-3.1-pro-grounding",
+    "name": "gemini-3.1-pro-grounding",
+    "displayName": "gemini-3.1-pro-grounding",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 6,
+    "rankByModality": {
+      "search": 6
+    }
+  },
+  {
+    "id": "019b1448-f74a-72de-b25d-8666618f8c5a",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.2-search",
+    "name": "gpt-5.2-search",
+    "displayName": "gpt-5.2-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 7,
+    "rankByModality": {
+      "search": 7
+    }
+  },
+  {
+    "id": "019ceb00-eef3-7df6-a025-00c9805ebd65",
+    "organization": "xai",
+    "provider": "xaiMultiAgentGrounding",
+    "publicName": "grok-4.20-multi-agent-beta-0309",
+    "name": "grok-4.20-multi-agent-beta-0309-search",
+    "displayName": "grok-4.20-multi-agent-beta-0309",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 8,
+    "rankByModality": {
+      "search": 8
+    }
+  },
+  {
+    "id": "019bda1f-3abc-783f-aac0-1ee102b247ba",
+    "organization": "google",
+    "provider": "googleVertexGlobalSearch",
+    "publicName": "gemini-3-flash-grounding",
+    "name": "gemini-3-flash-grounding",
+    "displayName": "gemini-3-flash-grounding",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 10,
+    "rankByModality": {
+      "search": 10
+    }
+  },
+  {
+    "id": "019abdb7-50a5-7c05-9308-4491d069578b",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.1-search",
+    "name": "gpt-5.1-search",
+    "displayName": "gpt-5.1-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 11,
+    "rankByModality": {
+      "search": 11
+    }
+  },
+  {
+    "id": "019cc0b6-0650-72eb-9294-47cb7e9a5d47",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.4-search",
+    "name": "gpt-5.4-search",
+    "displayName": "gpt-5.4-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 12,
+    "rankByModality": {
+      "search": 12
+    }
+  },
+  {
+    "id": "019c78bd-0d1b-7a3c-9d29-397a445768ed",
+    "organization": "xai",
+    "provider": "xaiResponsesSearchPrivate",
+    "publicName": "arastradero",
+    "name": "arastradero",
+    "displayName": "grok-4.20-beta1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 13,
+    "rankByModality": {
+      "search": 13
+    }
+  },
+  {
+    "id": "019bda1f-2da5-7e9b-b357-2ed018d39393",
+    "organization": "anthropic",
+    "provider": "anthropicSearch",
+    "publicName": "claude-opus-4-5-search",
+    "name": "claude-opus-4-5-search",
+    "displayName": "claude-opus-4-5-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 15,
+    "rankByModality": {
+      "search": 15
+    }
+  },
+  {
+    "id": "019bda1e-bf3f-705b-b791-36db7a6ba906",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.2-search-non-reasoning",
+    "name": "gpt-5.2-search-non-reasoning",
+    "displayName": "gpt-5.2-search-non-reasoning",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 16,
+    "rankByModality": {
+      "search": 16
+    }
+  },
+  {
+    "id": "019af19c-0658-7566-9c60-112ae5bdb8db",
+    "organization": "xai",
+    "provider": "xaiResponsesSearch",
+    "publicName": "grok-4-1-fast-search",
+    "name": "grok-4-1-fast-search",
+    "displayName": "grok-4-1-fast-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 17,
+    "rankByModality": {
+      "search": 17
+    }
+  },
+  {
+    "id": "9217ac2d-91bc-4391-aa07-b8f9e2cf11f2",
+    "organization": "xai",
+    "provider": "xaiResearchSearch",
+    "publicName": "grok-4-fast-search",
+    "name": "grok-4-fast-search",
+    "displayName": "grok-4-fast-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 18,
+    "rankByModality": {
+      "search": 18
+    }
+  },
+  {
+    "id": "019bda1f-3664-75d3-91b9-ede8f7561e44",
+    "organization": "anthropic",
+    "provider": "anthropicSearch",
+    "publicName": "claude-sonnet-4-5-search",
+    "name": "claude-sonnet-4-5-search",
+    "displayName": "claude-sonnet-4-5-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 19,
+    "rankByModality": {
+      "search": 19
+    }
+  },
+  {
+    "id": "d942b564-191c-41c5-ae22-400a930a2cfe",
+    "organization": "anthropic",
+    "provider": "anthropicSearch",
+    "publicName": "claude-opus-4-1-search",
+    "name": "claude-opus-4-1-search",
+    "displayName": "claude-opus-4-1-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 20,
+    "rankByModality": {
+      "search": 20
+    }
+  },
+  {
+    "id": "fbe08e9a-3805-4f9f-a085-7bc38e4b51d1",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "o3-search",
+    "name": "o3-search",
+    "displayName": "o3-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 21,
+    "rankByModality": {
+      "search": 21
+    }
+  },
+  {
+    "id": "b222be23-bd55-4b20-930b-a30cc84d3afd",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "gemini-2.5-pro-grounding",
+    "name": "gemini-2.5-pro-grounding",
+    "displayName": "gemini-2.5-pro-grounding",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 22,
+    "rankByModality": {
+      "search": 22
+    }
+  },
+  {
+    "id": "86d767b0-2574-4e47-a256-a22bcace9f56",
+    "organization": "xai",
+    "provider": "xaiSearch",
+    "publicName": "grok-4-search",
+    "name": "grok-4-search",
+    "displayName": "grok-4-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 23,
+    "rankByModality": {
+      "search": 23
+    }
+  },
+  {
+    "id": "24145149-86c9-4690-b7c9-79c7db216e5c",
+    "organization": "perplexity",
+    "provider": "perplexity",
+    "publicName": "ppl-sonar-reasoning-pro-high",
+    "name": "ppl-sonar-reasoning-pro-high",
+    "displayName": "ppl-sonar-reasoning-pro-high",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 24,
+    "rankByModality": {
+      "search": 24
+    }
+  },
+  {
+    "id": "d14d9b23-1e46-4659-b157-a3804ba7e2ef",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5-search",
+    "name": "gpt-5-search",
+    "displayName": "gpt-5-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 25,
+    "rankByModality": {
+      "search": 25
+    }
+  },
+  {
+    "id": "25bcb878-749e-49f4-ac05-de84d964bcee",
+    "organization": "anthropic",
+    "provider": "anthropicSearch",
+    "publicName": "claude-opus-4-search",
+    "name": "claude-opus-4-search",
+    "displayName": "claude-opus-4-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": false,
+    "rank": 27,
+    "rankByModality": {
+      "search": 27
+    }
+  },
+  {
+    "id": "019d888a-4f52-7a31-a253-769424b91df9",
+    "publicName": "anonymous-0410",
+    "displayName": "openhard-1.0-search-non-reasoning-0410",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "search": 9007199254740991
+    }
+  },
+  {
+    "id": "019c5985-3024-72b5-8ddf-43cb6f7cb529",
+    "publicName": "rising-sun",
+    "displayName": "rising-sun",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "search": 9007199254740991
+    }
+  },
+  {
+    "id": "019da20e-0d8e-718a-9187-a3fa69de67fd",
+    "publicName": "wild-bits",
+    "displayName": "wild-bits",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "search": 9007199254740991
+    }
+  },
+  {
+    "id": "019e0836-a13f-7e4f-ad00-3f32140afff3",
+    "publicName": "tanager-search",
+    "displayName": "tanager-search",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "search": 9007199254740991
+    }
+  },
+  {
+    "id": "019cc4af-dae4-7d38-acf6-3c2c867138ce",
+    "publicName": "basalt-0303-1",
+    "displayName": "basalt-0303-1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "search": 9007199254740991
+    }
+  },
+  {
+    "id": "019de22d-1445-7296-9c88-a5877bc66ef8",
+    "organization": "xai",
+    "provider": "xaiResponsesSearchPrivate",
+    "publicName": "grok-4.3",
+    "name": "grok-4.3-search",
+    "displayName": "grok-4.3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "search": 9007199254740991
+    }
+  },
+  {
+    "id": "019dda58-5541-705e-9db1-fce7ac5d55e5",
+    "publicName": "basalt-0422-1-v2",
+    "displayName": "basalt-0422-1-v2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "search": 9007199254740991
+    }
+  },
+  {
+    "id": "019b2f68-97ae-75b1-9e2f-456470bd5332",
+    "organization": "openai",
+    "provider": "openaiResponses",
+    "publicName": "gpt-5.1-search-sp",
+    "name": "gpt-5.1-search-new-system-prompt-20251217",
+    "displayName": "gpt-5.1-search-sp",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "search": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "search": 9007199254740991
+    }
+  },
+  {
+    "id": "019d4231-5b3d-72d1-aa8c-04841b8eab5f",
+    "organization": "bytedance",
+    "provider": "byteplus",
+    "publicName": "k2",
+    "name": "k2",
+    "displayName": "dreamina-seedance-2.0-720p",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true,
+        "video": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 1,
+    "rankByModality": {
+      "video": 1
+    }
+  },
+  {
+    "id": "019d8879-f448-76fc-b71d-8d10508fbf2c",
+    "organization": "aorizon",
+    "provider": "aorizon",
+    "publicName": "model-x-2",
+    "name": "model-x-2",
+    "displayName": "happyhorse-1.0",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 2,
+    "rankByModality": {
+      "video": 2
+    }
+  },
+  {
+    "id": "019bbe19-d2dd-7659-a63e-2ec3523002fa",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "veo-3.1-audio-1080p",
+    "name": "veo-3.1-audio-1080p",
+    "displayName": "veo-3.1-audio-1080p",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 3,
+    "rankByModality": {
+      "video": 3
+    }
+  },
+  {
+    "id": "01f39601-03ed-4d66-8afb-5039c90b27ea",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "sora-2-pro",
+    "name": "sora-2-pro",
+    "displayName": "sora-2-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 4,
+    "rankByModality": {
+      "video": 4
+    }
+  },
+  {
+    "id": "0199eacf-0d64-736a-8309-07cc254b849d",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "veo-3.1-audio",
+    "name": "veo-3.1-audio",
+    "displayName": "veo-3.1-audio",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 5,
+    "rankByModality": {
+      "video": 5
+    }
+  },
+  {
+    "id": "0199eacf-1119-7e20-a53e-86b740c32f03",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "veo-3.1-fast-audio",
+    "name": "veo-3.1-fast-audio",
+    "displayName": "veo-3.1-fast-audio",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 6,
+    "rankByModality": {
+      "video": 6
+    }
+  },
+  {
+    "id": "019bbe1b-3c52-73e0-a46f-439345e18b60",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "veo-3.1-fast-audio-1080p",
+    "name": "veo-3.1-fast-audio-1080p",
+    "displayName": "veo-3.1-fast-audio-1080p",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 7,
+    "rankByModality": {
+      "video": 7
+    }
+  },
+  {
+    "id": "9bbbca46-b6c2-4919-83a8-87ef1c559c4e",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "veo-3-fast-audio",
+    "name": "veo-3-fast-audio",
+    "displayName": "veo-3-fast-audio",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 9,
+    "rankByModality": {
+      "video": 9
+    }
+  },
+  {
+    "id": "019c48d2-6244-73d5-b6f0-c138efff5331",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "wan2.6-t2v",
+    "name": "wan2.6-t2v",
+    "displayName": "wan2.6-t2v",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": false
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 10,
+    "rankByModality": {
+      "video": 10
+    }
+  },
+  {
+    "id": "043a03a9-a792-4045-9f6d-4bcd747dac43",
+    "organization": "openai",
+    "provider": "openai",
+    "publicName": "sora-2",
+    "name": "sora-2",
+    "displayName": "sora-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 12,
+    "rankByModality": {
+      "video": 12
+    }
+  },
+  {
+    "id": "019a74c8-5bf5-7f37-b0c4-4d597ea6f831",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "wan2.5-t2v-preview",
+    "name": "wan2.5-t2v-preview",
+    "displayName": "wan2.5-t2v-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": false
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 13,
+    "rankByModality": {
+      "video": 13
+    }
+  },
+  {
+    "id": "019b70d2-e820-7dd8-97da-f78134489b1a",
+    "organization": "bytedance",
+    "provider": "fal",
+    "publicName": "seedance-v1.5-pro",
+    "name": "seedance-v1.5-pro-text-to-video",
+    "displayName": "seedance-v1.5-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 14,
+    "rankByModality": {
+      "video": 14
+    }
+  },
+  {
+    "id": "019b70d5-d1b4-70e3-804f-8afeb937dba5",
+    "organization": "bytedance",
+    "provider": "fal",
+    "publicName": "seedance-v1.5-pro",
+    "name": "seedance-v1.5-pro-image-to-video",
+    "displayName": "seedance-v1.5-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 14,
+    "rankByModality": {
+      "video": 14
+    }
+  },
+  {
+    "id": "019c920d-8d0e-7625-a023-635cf4e9f5d5",
+    "organization": "runway",
+    "provider": "replicate",
+    "publicName": "runway-gen-4.5",
+    "name": "runway-gen-4.5-text-to-video",
+    "displayName": "runway-gen-4.5",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 18,
+    "rankByModality": {
+      "video": 18
+    }
+  },
+  {
+    "id": "4cd188c8-4671-45a0-8433-dd89ce4e16a5",
+    "organization": "kling",
+    "provider": "kling",
+    "publicName": "kling-2.5-turbo-1080p",
+    "name": "kling-2.5-turbo-1080p",
+    "displayName": "kling-2.5-turbo-1080p",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 19,
+    "rankByModality": {
+      "video": 19
+    }
+  },
+  {
+    "id": "019aebd1-edc0-71c9-906d-82656c3d8927",
+    "organization": "kling",
+    "provider": "fal",
+    "publicName": "kling-2.6-pro",
+    "name": "kling-2.6-pro-text-to-video-fal",
+    "displayName": "kling-2.6-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 20,
+    "rankByModality": {
+      "video": 20
+    }
+  },
+  {
+    "id": "019aebd1-e566-7009-9190-f6178cd6f9ac",
+    "organization": "kling",
+    "provider": "fal",
+    "publicName": "kling-2.6-pro",
+    "name": "kling-2.6-pro-image-to-video-fal",
+    "displayName": "kling-2.6-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 20,
+    "rankByModality": {
+      "video": 20
+    }
+  },
+  {
+    "id": "019c7c99-b7d8-7a24-961a-3cec146ecefd",
+    "publicName": "pixel-parrot",
+    "displayName": "pixel-parrot",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 21,
+    "rankByModality": {
+      "video": 21
+    }
+  },
+  {
+    "id": "019c7c99-f606-714a-9791-e51f3c1ac0b5",
+    "publicName": "pixel-parrot",
+    "displayName": "pixel-parrot",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 21,
+    "rankByModality": {
+      "video": 21
+    }
+  },
+  {
+    "id": "fec7074d-a3a0-4f83-a487-82700fcec84d",
+    "organization": "luma-ai",
+    "provider": "luma",
+    "publicName": "ray-3",
+    "name": "ray-3",
+    "displayName": "ray-3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 22,
+    "rankByModality": {
+      "video": 22
+    }
+  },
+  {
+    "id": "019c78d9-c9b1-777a-9792-e0790121359d",
+    "organization": "kling",
+    "provider": "fal",
+    "publicName": "kling-o1-pro",
+    "name": "kling-o1-pro-video-to-video",
+    "displayName": "kling-o1-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "video": {
+          "required": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 23,
+    "rankByModality": {
+      "video": 23
+    }
+  },
+  {
+    "id": "019be7ad-5596-7d09-adf2-bf3ada092cf3",
+    "organization": "kling",
+    "provider": "kling",
+    "publicName": "kling-o1-pro",
+    "name": "kling-o1-pro-20260121",
+    "displayName": "kling-o1-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 23,
+    "rankByModality": {
+      "video": 23
+    }
+  },
+  {
+    "id": "527e3f88-c13f-404c-92b4-0dcf7eeb61e6",
+    "organization": "minimax",
+    "provider": "fal",
+    "publicName": "hailuo-02-pro",
+    "name": "hailuo-02-pro-image-to-video",
+    "displayName": "hailuo-02-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 24,
+    "rankByModality": {
+      "video": 24
+    }
+  },
+  {
+    "id": "55069e04-a634-4d98-8765-95113b945f5e",
+    "organization": "minimax",
+    "provider": "fal",
+    "publicName": "hailuo-02-pro",
+    "name": "hailuo-02-pro-text-to-video",
+    "displayName": "hailuo-02-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 24,
+    "rankByModality": {
+      "video": 24
+    }
+  },
+  {
+    "id": "019a1e21-7cb0-7778-9dd0-02ed4fb3563f",
+    "organization": "minimax",
+    "provider": "minimax",
+    "publicName": "hailuo-2.3",
+    "name": "hailuo-2.3",
+    "displayName": "hailuo-2.3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": false
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 25,
+    "rankByModality": {
+      "video": 25
+    }
+  },
+  {
+    "id": "4ddc4e52-2867-49b6-a603-5aab24a566ca",
+    "organization": "bytedance",
+    "provider": "fal",
+    "publicName": "seedance-v1-pro",
+    "name": "seedance-v1-pro-image-to-video",
+    "displayName": "seedance-v1-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 26,
+    "rankByModality": {
+      "video": 26
+    }
+  },
+  {
+    "id": "e705b65f-82cd-40cb-9630-d9e6ca92d06f",
+    "organization": "bytedance",
+    "provider": "fal",
+    "publicName": "seedance-v1-pro",
+    "name": "seedance-v1-pro-text-to-video",
+    "displayName": "seedance-v1-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 26,
+    "rankByModality": {
+      "video": 26
+    }
+  },
+  {
+    "id": "e652c45e-8699-4392-94f0-7834e7464137",
+    "organization": "minimax",
+    "provider": "fal",
+    "publicName": "hailuo-02-standard",
+    "name": "hailuo-02-standard-text-to-video",
+    "displayName": "hailuo-02-standard",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 27,
+    "rankByModality": {
+      "video": 27
+    }
+  },
+  {
+    "id": "bf03b5bb-8b4e-4a36-a893-0b2809f1daec",
+    "organization": "minimax",
+    "provider": "fal",
+    "publicName": "hailuo-02-standard",
+    "name": "hailuo-02-standard-image-to-video",
+    "displayName": "hailuo-02-standard",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 27,
+    "rankByModality": {
+      "video": 27
+    }
+  },
+  {
+    "id": "019a997a-92dd-7588-ac3c-bdca7e81af37",
+    "organization": "kandinsky",
+    "provider": "kandinsky",
+    "publicName": "kandinsky-5.0-t2v-pro",
+    "name": "kandinsky-5.0-t2v-pro",
+    "displayName": "kandinsky-5.0-t2v-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 28,
+    "rankByModality": {
+      "video": 28
+    }
+  },
+  {
+    "id": "019b28b8-5801-708c-9a7c-e77999d624d6",
+    "organization": "tencent",
+    "provider": "tencent",
+    "publicName": "hunyuan-video-1.5",
+    "name": "hunyuan-video-1.5-t2v-20251209",
+    "displayName": "hunyuan-video-1.5",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 29,
+    "rankByModality": {
+      "video": 29
+    }
+  },
+  {
+    "id": "019b28b8-671b-7d8c-9d32-0cd757a60a6c",
+    "organization": "tencent",
+    "provider": "tencent",
+    "publicName": "hunyuan-video-1.5",
+    "name": "hunyuan-video-1.5-i2v-20251209",
+    "displayName": "hunyuan-video-1.5",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 29,
+    "rankByModality": {
+      "video": 29
+    }
+  },
+  {
+    "id": "08d8dcc6-2ab5-45ae-9bf1-353480f1f7ee",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "veo-2",
+    "name": "veo-2",
+    "displayName": "veo-2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 30,
+    "rankByModality": {
+      "video": 30
+    }
+  },
+  {
+    "id": "d63b03fb-8bc8-4ed8-9a50-6ccb683ac2b1",
+    "organization": "kling",
+    "provider": "fal",
+    "publicName": "kling-v2.1-master",
+    "name": "kling-v2.1-master-text-to-video",
+    "displayName": "kling-v2.1-master",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 31,
+    "rankByModality": {
+      "video": 31
+    }
+  },
+  {
+    "id": "efdb7e05-2091-4e88-af9e-4ea6168d2f85",
+    "organization": "kling",
+    "provider": "fal",
+    "publicName": "kling-v2.1-master",
+    "name": "kling-v2.1-master-image-to-video",
+    "displayName": "kling-v2.1-master",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 31,
+    "rankByModality": {
+      "video": 31
+    }
+  },
+  {
+    "id": "019bb42e-e9ee-75ca-9967-559a2bfb6c8b",
+    "organization": "lightricks",
+    "provider": "fal",
+    "publicName": "ltx-2-19b",
+    "name": "ltx-2-19b-image-to-video",
+    "displayName": "ltx-2-19b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 32,
+    "rankByModality": {
+      "video": 32
+    }
+  },
+  {
+    "id": "019bb42e-a2f0-73e6-a96e-a6f925341d9c",
+    "organization": "lightricks",
+    "provider": "fal",
+    "publicName": "ltx-2-19b",
+    "name": "ltx-2-19b-text-to-video",
+    "displayName": "ltx-2-19b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 32,
+    "rankByModality": {
+      "video": 32
+    }
+  },
+  {
+    "id": "3a91bb37-39fb-471c-8aa2-a89b98d280d0",
+    "organization": "alibaba",
+    "provider": "fal",
+    "publicName": "wan-v2.2-a14b",
+    "name": "wan-v2.2-a14b-image-to-video",
+    "displayName": "wan-v2.2-a14b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 33,
+    "rankByModality": {
+      "video": 33
+    }
+  },
+  {
+    "id": "264e6e2f-b66a-4e27-a859-8145ff32d6f6",
+    "organization": "alibaba",
+    "provider": "fal",
+    "publicName": "wan-v2.2-a14b",
+    "name": "wan-v2.2-a14b-text-to-video",
+    "displayName": "wan-v2.2-a14b",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 33,
+    "rankByModality": {
+      "video": 33
+    }
+  },
+  {
+    "id": "019a997a-88a7-7e5c-9214-ed2a946eb739",
+    "organization": "kandinsky",
+    "provider": "kandinsky",
+    "publicName": "kandinsky-5.0-t2v-lite",
+    "name": "kandinsky-5.0-t2v-lite",
+    "displayName": "kandinsky-5.0-t2v-lite",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 34,
+    "rankByModality": {
+      "video": 34
+    }
+  },
+  {
+    "id": "13ce11ba-def2-4c80-a70b-b0b2c14d293e",
+    "organization": "bytedance",
+    "provider": "fal",
+    "publicName": "seedance-v1-lite",
+    "name": "seedance-v1-lite-text-to-video",
+    "displayName": "seedance-v1-lite",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 35,
+    "rankByModality": {
+      "video": 35
+    }
+  },
+  {
+    "id": "4c8dde6e-1b2c-45b9-91c3-413b2ceafffb",
+    "organization": "bytedance",
+    "provider": "fal",
+    "publicName": "seedance-v1-lite",
+    "name": "seedance-v1-lite-image-to-video",
+    "displayName": "seedance-v1-lite",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 35,
+    "rankByModality": {
+      "video": 35
+    }
+  },
+  {
+    "id": "c3d0e5c8-f4b3-417a-8cb8-2ccf757d3869",
+    "organization": "openai",
+    "provider": "azureOpenAI",
+    "publicName": "sora",
+    "name": "sora",
+    "displayName": "sora",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 36,
+    "rankByModality": {
+      "video": 36
+    }
+  },
+  {
+    "id": "217158f9-793e-4ffe-a197-6de9448432fc",
+    "organization": "luma-ai",
+    "provider": "fal",
+    "publicName": "ray2",
+    "name": "ray2",
+    "displayName": "ray2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 37,
+    "rankByModality": {
+      "video": 37
+    }
+  },
+  {
+    "id": "5b3383a9-6bca-4f71-8210-78895c9d84d5",
+    "organization": "luma-ai",
+    "provider": "fal",
+    "publicName": "ray2",
+    "name": "ray2-image-to-video",
+    "displayName": "ray2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 37,
+    "rankByModality": {
+      "video": 37
+    }
+  },
+  {
+    "id": "f9b9f030-9ebc-4765-bf76-c64a82a72dfd",
+    "organization": "pika",
+    "provider": "fal",
+    "publicName": "pika-v2.2",
+    "name": "pika-v2.2-image-to-video",
+    "displayName": "pika-v2.2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 38,
+    "rankByModality": {
+      "video": 38
+    }
+  },
+  {
+    "id": "86de5aea-fc0c-4c36-b65a-7afc443a32d2",
+    "organization": "pika",
+    "provider": "fal",
+    "publicName": "pika-v2.2",
+    "name": "pika-v2.2-text-to-video",
+    "displayName": "pika-v2.2",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 38,
+    "rankByModality": {
+      "video": 38
+    }
+  },
+  {
+    "id": "f4809219-14a8-47fe-9705-8685085513e7",
+    "organization": "genmo",
+    "provider": "fal",
+    "publicName": "mochi-v1",
+    "name": "mochi-v1",
+    "displayName": "mochi-v1",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rank": 39,
+    "rankByModality": {
+      "video": 39
+    }
+  },
+  {
+    "id": "019de0ba-9071-7116-894f-0bfef86db47c",
+    "publicName": "tbd",
+    "displayName": "tbd",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "video": {
+          "required": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019d25f6-fa25-747c-96b0-9d6f0ee9ff8e",
+    "publicName": "markhor",
+    "displayName": "markhor",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019a36dd-5d6c-7f15-8598-4755f4c34e28",
+    "organization": "minimax",
+    "provider": "minimax",
+    "publicName": "hailuo-2.3-fast",
+    "name": "hailuo-2.3-fast",
+    "displayName": "hailuo-2.3-fast",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019d6948-1f6c-7412-ae0d-012623e3d670",
+    "organization": "aorizon",
+    "provider": "aorizon",
+    "publicName": "model-x",
+    "name": "model-x-video-edit",
+    "displayName": "happyhorse-1.0",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "video": {
+          "required": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019c78da-3629-73c6-8e04-0aba8eae64c8",
+    "organization": "runway",
+    "provider": "replicate",
+    "publicName": "runway-gen4-aleph",
+    "name": "runway-gen4-aleph-video-to-video",
+    "displayName": "runway-gen4-aleph",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "video": {
+          "required": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019cb6f1-7a29-7020-9b21-263d43c8e7c7",
+    "organization": "pixverse",
+    "provider": "fal",
+    "publicName": "pixverse-v5.6",
+    "name": "pixverse-v5.6-image-to-video",
+    "displayName": "pixverse-v5.6",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019c05a7-15e7-7305-adc2-0d5939fd6799",
+    "organization": "shengshu",
+    "provider": "shengshu",
+    "publicName": "snowflake",
+    "name": "snowflake-v2",
+    "displayName": "vidu-q3-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019bbe19-2e09-772e-abaa-5fa9189935e0",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "veo-3.1-audio-4k",
+    "name": "veo-3.1-audio-4k",
+    "displayName": "veo-3.1-audio-4k",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019c78d9-2a0f-7d8d-8b01-94bf9907d65e",
+    "organization": "alibaba",
+    "provider": "fal",
+    "publicName": "wan-vace",
+    "name": "wan-vace-video-to-video",
+    "displayName": "wan-vace",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "video": {
+          "required": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019c78d9-ffe4-7a3a-913f-9570e3927788",
+    "organization": "kling",
+    "provider": "fal",
+    "publicName": "kling-o3-pro",
+    "name": "kling-o3-pro-video-to-video",
+    "displayName": "kling-o3-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "video": {
+          "required": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019cb266-4908-701c-9bea-a97757b5569f",
+    "organization": "pixverse",
+    "provider": "fal",
+    "publicName": "pixverse-v5.6",
+    "name": "pixverse-v5.6-text-to-video",
+    "displayName": "pixverse-v5.6",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019a3c95-c431-79fe-9298-09cce3f449f3",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "wan2.5-i2v-preview",
+    "name": "wan2.5-i2v-preview",
+    "displayName": "wan2.5-i2v-preview",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019de5a8-bff1-7059-a714-a62306010c70",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "wan2.7-t2v",
+    "name": "wan2.7-t2v-2026-04-25",
+    "displayName": "wan2.7-t2v",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019de98f-d58e-7524-ae2b-9d18b0d35838",
+    "publicName": "polaris",
+    "displayName": "polaris",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019c59fa-6567-7c42-97af-f51b52ce47d5",
+    "organization": "kling",
+    "provider": "fal",
+    "publicName": "kling-v3",
+    "name": "kling-v3-text-to-video",
+    "displayName": "kling-v3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019e1cd6-1907-7b7c-837c-33a5a3b33b95",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "wan2.7-i2v",
+    "name": "wan2.7-i2v-2026-04-25-v2",
+    "displayName": "wan2.7-i2v",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019c8d5a-ebf3-78a9-b086-33719c7be210",
+    "organization": "kandinsky",
+    "provider": "kandinsky",
+    "publicName": "kandinsky-5.0-i2v-pro",
+    "name": "kandinsky-5.0-i2v-pro",
+    "displayName": "kandinsky-5.0-i2v-pro",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019be7ad-09a7-716d-a412-21bbbca7263c",
+    "organization": "kling",
+    "provider": "kling",
+    "publicName": "kling-2.6-standard",
+    "name": "kling-2.6-standard-20260121",
+    "displayName": "kling-2.6-standard",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019bbe1a-96bb-7e35-aa57-c7b68a20d787",
+    "organization": "google",
+    "provider": "googleVertex",
+    "publicName": "veo-3.1-fast-audio-4k",
+    "name": "veo-3.1-fast-audio-4k",
+    "displayName": "veo-3.1-fast-audio-4k",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "0754baa1-ab91-42d0-ba74-522aa8e5b8e2",
+    "organization": "runway",
+    "provider": "replicate",
+    "publicName": "runway-gen4-turbo",
+    "name": "runway-gen4-turbo",
+    "displayName": "runway-gen4-turbo",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019c78d9-8148-794d-ba5e-59c1a29a1dc3",
+    "organization": "xai",
+    "provider": "xai",
+    "publicName": "grok-imagine-video",
+    "name": "grok-imagine-video-video-to-video",
+    "displayName": "grok-imagine-video",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "video": {
+          "required": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019c59fa-8a41-7042-baf7-121d052c04b8",
+    "organization": "kling",
+    "provider": "fal",
+    "publicName": "kling-v3",
+    "name": "kling-v3-image-to-video",
+    "displayName": "kling-v3",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019c2116-1107-7146-b617-c70a53abcb3f",
+    "organization": "xai",
+    "provider": "xai",
+    "publicName": "grok-imagine-video",
+    "name": "grok-imagine-video-720p",
+    "displayName": "grok-imagine-video",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": true
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "ea96cfc8-953a-4c3c-a229-1107c55b7479",
+    "organization": "kling",
+    "provider": "fal",
+    "publicName": "kling-v2.1-standard",
+    "name": "kling-v2.1-standard",
+    "displayName": "kling-v2.1-standard",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "58060613-41dc-478b-97a0-6d9c4f0c722a",
+    "organization": "minimax",
+    "provider": "fal",
+    "publicName": "hailuo-02-fast",
+    "name": "hailuo-02-fast",
+    "displayName": "hailuo-02-fast",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  },
+  {
+    "id": "019c48d2-0f86-701d-beb2-af070edd1147",
+    "organization": "alibaba",
+    "provider": "alibaba",
+    "publicName": "wan2.6-i2v",
+    "name": "wan2.6-i2v",
+    "displayName": "wan2.6-i2v",
+    "capabilities": {
+      "inputCapabilities": {
+        "text": true,
+        "image": {
+          "requiresUpload": true
+        }
+      },
+      "outputCapabilities": {
+        "video": true
+      }
+    },
+    "userSelectable": true,
+    "rankByModality": {
+      "video": 9007199254740991
+    }
+  }
+]

--- a/src/main.py
+++ b/src/main.py
@@ -2658,24 +2658,41 @@ async def api_chat_completions(request: Request, api_key: dict = Depends(rate_li
                         debug_print(f"📝 Failed tokens so far: {len(failed_tokens)}")
 
                         if attempt < max_retries - 1:
-                            # Try to refresh the failed token via LMArena HTTP before giving up.
                             # A 401 can mean the session needs a server-side refresh (Set-Cookie rotation),
-                            # not that the token is permanently invalid.
+                            # not that the token is permanently invalid. Try multiple refresh strategies:
+                            #   1) maybe_refresh_expired_auth_tokens (handles already-expired tokens in the pool)
+                            #   2) Direct LMArena HTTP refresh on the current token (works even if not expired yet)
+                            #   3) Fall back to next token in rotation
                             refreshed_token = None
                             if current_token.startswith("base64-"):
                                 debug_print("🔄 Attempting to refresh auth token via LMArena HTTP...")
+
+                                # Strategy 1: try refreshing any expired token in the pool
                                 try:
                                     refreshed_token = await maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
                                 except Exception:
                                     refreshed_token = None
+
+                                # Strategy 2: if pool refresh didn't help, try direct LMArena HTTP refresh
+                                # on the current token itself. This handles the case where a non-expired
+                                # token gets a 401 (server-side session invalidation, token rotation, etc.)
+                                if not refreshed_token:
+                                    try:
+                                        refreshed_token = await refresh_arena_auth_token_via_lmarena_http(current_token)
+                                    except Exception:
+                                        refreshed_token = None
+                                    if refreshed_token:
+                                        debug_print("✅ Direct LMArena HTTP refresh succeeded for current token.")
+
                                 if refreshed_token:
                                     current_token = refreshed_token
+                                    failed_tokens.discard(current_token)
                                     headers = get_request_headers_with_token(current_token, recaptcha_token)
-                                    debug_print(f"✅ Token refreshed successfully, retrying...")
+                                    debug_print("✅ Token refreshed successfully, retrying...")
                                     await asyncio.sleep(1)
                                     continue
                                 else:
-                                    debug_print("⚠️ Token refresh failed, trying next token...")
+                                    debug_print("⚠️ All token refresh strategies failed, trying next token...")
 
                             try:
                                 current_token = get_next_auth_token(exclude_tokens=failed_tokens)
@@ -4264,22 +4281,40 @@ async def api_chat_completions(request: Request, api_key: dict = Depends(rate_li
                                 yield f"data: {json.dumps(error_chunk)}\n\n"
                                 yield "data: [DONE]\n\n"
                                 return
-                            # Try to refresh the auth token before rotating to next one
+                            # Try to refresh the auth token before rotating to next one.
+                            # Use multiple refresh strategies:
+                            #   1) maybe_refresh_expired_auth_tokens (handles already-expired tokens in the pool)
+                            #   2) Direct LMArena HTTP refresh on the current token (works even if not expired yet)
+                            #   3) Fall back to next token in rotation
                             if current_token and current_token.startswith("base64-"):
                                 debug_print("🔄 Stream 401: attempting to refresh auth token via LMArena HTTP...")
+                                refreshed_token = None
+
+                                # Strategy 1: try refreshing any expired token in the pool
                                 try:
                                     refreshed_token = await maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
                                 except Exception:
                                     refreshed_token = None
+
+                                # Strategy 2: direct LMArena HTTP refresh on the current token
+                                if not refreshed_token:
+                                    try:
+                                        refreshed_token = await refresh_arena_auth_token_via_lmarena_http(current_token)
+                                    except Exception:
+                                        refreshed_token = None
+                                    if refreshed_token:
+                                        debug_print("✅ Stream: direct LMArena HTTP refresh succeeded.")
+
                                 if refreshed_token:
                                     current_token = refreshed_token
+                                    failed_tokens.discard(current_token)
                                     headers = get_request_headers_with_token(current_token, recaptcha_token)
                                     debug_print("✅ Stream token refreshed successfully, retrying...")
                                     async for ka in wait_with_keepalive(1.0):
                                         yield ka
                                     continue
                                 else:
-                                    debug_print("⚠️ Stream token refresh failed, trying next token...")
+                                    debug_print("⚠️ Stream: all token refresh strategies failed, trying next token...")
                             # Try next token in rotation
                             try:
                                 current_token = get_next_auth_token(exclude_tokens=failed_tokens)

--- a/src/main.py
+++ b/src/main.py
@@ -1035,6 +1035,28 @@ async def get_initial_data():
                 pass
 
             debug_print("✅ Initial data retrieval complete")
+
+            # Capture provisional_user_id from browser cookies if present.
+            # The arena.ai frontend may set this cookie during page load.
+            # We do NOT attempt anonymous signup here because:
+            #   1. The signup endpoint requires reCAPTCHA which fails in headless mode
+            #   2. Even if signup succeeds, the provisional user cannot create evaluations
+            #   3. The Camoufox transport (PR #175) has its own anonymous signup flow
+            #      that handles Turnstile/reCAPTCHA challenges properly.
+            # Without a persisted auth token, the server falls back to browser transport
+            # which has the best chance of obtaining a working session.
+            try:
+                cookies = await page.context.cookies()
+                for c in cookies:
+                    if c.get("name") == "provisional_user_id" and c.get("value"):
+                        pid = str(c["value"]).strip()
+                        cfg = get_config()
+                        cfg["provisional_user_id"] = pid
+                        save_config(cfg, preserve_auth_tokens=False)
+                        debug_print(f"✅ Captured provisional_user_id: {pid[:8]}...")
+                        break
+            except Exception as cookie_err:
+                debug_print(f"⚠️ Error capturing provisional_user_id: {cookie_err}")
     except Exception as e:
         debug_print(f"❌ An error occurred during initial data retrieval: {e}")
 

--- a/src/main.py
+++ b/src/main.py
@@ -745,6 +745,45 @@ def get_request_headers():
     
     return get_request_headers_with_token(token)
 
+
+async def try_refresh_arena_auth_token(current_token: str, failed_tokens: set[str]) -> Optional[str]:
+    """
+    Try multiple refresh strategies for a 401'd auth token.
+
+    1) maybe_refresh_expired_auth_tokens — checks if any expired token in the pool can be refreshed
+    2) refresh_arena_auth_token_via_lmarena_http — directly refreshes the current token via LMArena HTTP
+
+    Returns a refreshed token string, or None if all strategies failed.
+    """
+    if not current_token or not current_token.startswith("base64-"):
+        return None
+
+    debug_print("🔄 Attempting to refresh auth token via LMArena HTTP...")
+
+    # Strategy 1: try refreshing any expired token in the pool
+    try:
+        refreshed_token = await maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
+    except Exception:
+        refreshed_token = None
+
+    # Strategy 2: if pool refresh didn't help, try direct LMArena HTTP refresh
+    # on the current token itself. This handles the case where a non-expired
+    # token gets a 401 (server-side session invalidation, token rotation, etc.)
+    if not refreshed_token:
+        try:
+            refreshed_token = await refresh_arena_auth_token_via_lmarena_http(current_token)
+        except Exception:
+            refreshed_token = None
+        if refreshed_token:
+            debug_print("✅ Direct LMArena HTTP refresh succeeded for current token.")
+
+    if refreshed_token:
+        return refreshed_token
+
+    debug_print("⚠️ All token refresh strategies failed, trying next token...")
+    return None
+
+
 # --- Dashboard Authentication ---
 
 async def get_current_session(request: Request):
@@ -1052,7 +1091,7 @@ async def get_initial_data():
                         pid = str(c["value"]).strip()
                         cfg = get_config()
                         cfg["provisional_user_id"] = pid
-                        save_config(cfg, preserve_auth_tokens=False)
+                        save_config(cfg)
                         debug_print(f"✅ Captured provisional_user_id: {pid[:8]}...")
                         break
             except Exception as cookie_err:
@@ -2680,41 +2719,16 @@ async def api_chat_completions(request: Request, api_key: dict = Depends(rate_li
                         debug_print(f"📝 Failed tokens so far: {len(failed_tokens)}")
 
                         if attempt < max_retries - 1:
-                            # A 401 can mean the session needs a server-side refresh (Set-Cookie rotation),
-                            # not that the token is permanently invalid. Try multiple refresh strategies:
-                            #   1) maybe_refresh_expired_auth_tokens (handles already-expired tokens in the pool)
-                            #   2) Direct LMArena HTTP refresh on the current token (works even if not expired yet)
-                            #   3) Fall back to next token in rotation
-                            refreshed_token = None
-                            if current_token.startswith("base64-"):
-                                debug_print("🔄 Attempting to refresh auth token via LMArena HTTP...")
-
-                                # Strategy 1: try refreshing any expired token in the pool
-                                try:
-                                    refreshed_token = await maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
-                                except Exception:
-                                    refreshed_token = None
-
-                                # Strategy 2: if pool refresh didn't help, try direct LMArena HTTP refresh
-                                # on the current token itself. This handles the case where a non-expired
-                                # token gets a 401 (server-side session invalidation, token rotation, etc.)
-                                if not refreshed_token:
-                                    try:
-                                        refreshed_token = await refresh_arena_auth_token_via_lmarena_http(current_token)
-                                    except Exception:
-                                        refreshed_token = None
-                                    if refreshed_token:
-                                        debug_print("✅ Direct LMArena HTTP refresh succeeded for current token.")
-
-                                if refreshed_token:
-                                    current_token = refreshed_token
-                                    failed_tokens.discard(current_token)
-                                    headers = get_request_headers_with_token(current_token, recaptcha_token)
-                                    debug_print("✅ Token refreshed successfully, retrying...")
-                                    await asyncio.sleep(1)
-                                    continue
-                                else:
-                                    debug_print("⚠️ All token refresh strategies failed, trying next token...")
+                            refreshed_token = await try_refresh_arena_auth_token(current_token, failed_tokens)
+                            if refreshed_token:
+                                global EPHEMERAL_ARENA_AUTH_TOKEN
+                                EPHEMERAL_ARENA_AUTH_TOKEN = refreshed_token
+                                current_token = refreshed_token
+                                failed_tokens.discard(current_token)
+                                headers = get_request_headers_with_token(current_token, recaptcha_token)
+                                debug_print("✅ Token refreshed successfully, retrying...")
+                                await asyncio.sleep(1)
+                                continue
 
                             try:
                                 current_token = get_next_auth_token(exclude_tokens=failed_tokens)
@@ -2742,6 +2756,7 @@ async def api_chat_completions(request: Request, api_key: dict = Depends(rate_li
             async def generate_stream():
                 nonlocal current_token, headers, failed_tokens, recaptcha_token
                 nonlocal session_id, user_msg_id, model_msg_id, model_b_msg_id
+                global EPHEMERAL_ARENA_AUTH_TOKEN
                 
                 # Safety: don't keep client sockets open forever on repeated upstream failures.
                 try:
@@ -3727,7 +3742,6 @@ async def api_chat_completions(request: Request, api_key: dict = Depends(rate_li
                                                 refreshed_token = None
 
                                     if refreshed_token:
-                                        global EPHEMERAL_ARENA_AUTH_TOKEN
                                         EPHEMERAL_ARENA_AUTH_TOKEN = refreshed_token
                                         current_token = refreshed_token
                                         headers = get_request_headers_with_token(current_token, recaptcha_token)
@@ -4303,41 +4317,17 @@ async def api_chat_completions(request: Request, api_key: dict = Depends(rate_li
                                 yield f"data: {json.dumps(error_chunk)}\n\n"
                                 yield "data: [DONE]\n\n"
                                 return
-                            # Try to refresh the auth token before rotating to next one.
-                            # Use multiple refresh strategies:
-                            #   1) maybe_refresh_expired_auth_tokens (handles already-expired tokens in the pool)
-                            #   2) Direct LMArena HTTP refresh on the current token (works even if not expired yet)
-                            #   3) Fall back to next token in rotation
-                            if current_token and current_token.startswith("base64-"):
-                                debug_print("🔄 Stream 401: attempting to refresh auth token via LMArena HTTP...")
-                                refreshed_token = None
+                            refreshed_token = await try_refresh_arena_auth_token(current_token, failed_tokens)
+                            if refreshed_token:
+                                EPHEMERAL_ARENA_AUTH_TOKEN = refreshed_token
+                                current_token = refreshed_token
+                                failed_tokens.discard(current_token)
+                                headers = get_request_headers_with_token(current_token, recaptcha_token)
+                                debug_print("✅ Stream token refreshed successfully, retrying...")
+                                async for ka in wait_with_keepalive(1.0):
+                                    yield ka
+                                continue
 
-                                # Strategy 1: try refreshing any expired token in the pool
-                                try:
-                                    refreshed_token = await maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
-                                except Exception:
-                                    refreshed_token = None
-
-                                # Strategy 2: direct LMArena HTTP refresh on the current token
-                                if not refreshed_token:
-                                    try:
-                                        refreshed_token = await refresh_arena_auth_token_via_lmarena_http(current_token)
-                                    except Exception:
-                                        refreshed_token = None
-                                    if refreshed_token:
-                                        debug_print("✅ Stream: direct LMArena HTTP refresh succeeded.")
-
-                                if refreshed_token:
-                                    current_token = refreshed_token
-                                    failed_tokens.discard(current_token)
-                                    headers = get_request_headers_with_token(current_token, recaptcha_token)
-                                    debug_print("✅ Stream token refreshed successfully, retrying...")
-                                    async for ka in wait_with_keepalive(1.0):
-                                        yield ka
-                                    continue
-                                else:
-                                    debug_print("⚠️ Stream: all token refresh strategies failed, trying next token...")
-                            # Try next token in rotation
                             try:
                                 current_token = get_next_auth_token(exclude_tokens=failed_tokens)
                                 headers = get_request_headers_with_token(current_token, recaptcha_token)

--- a/src/main.py
+++ b/src/main.py
@@ -2658,6 +2658,25 @@ async def api_chat_completions(request: Request, api_key: dict = Depends(rate_li
                         debug_print(f"📝 Failed tokens so far: {len(failed_tokens)}")
 
                         if attempt < max_retries - 1:
+                            # Try to refresh the failed token via LMArena HTTP before giving up.
+                            # A 401 can mean the session needs a server-side refresh (Set-Cookie rotation),
+                            # not that the token is permanently invalid.
+                            refreshed_token = None
+                            if current_token.startswith("base64-"):
+                                debug_print("🔄 Attempting to refresh auth token via LMArena HTTP...")
+                                try:
+                                    refreshed_token = await maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
+                                except Exception:
+                                    refreshed_token = None
+                                if refreshed_token:
+                                    current_token = refreshed_token
+                                    headers = get_request_headers_with_token(current_token, recaptcha_token)
+                                    debug_print(f"✅ Token refreshed successfully, retrying...")
+                                    await asyncio.sleep(1)
+                                    continue
+                                else:
+                                    debug_print("⚠️ Token refresh failed, trying next token...")
+
                             try:
                                 current_token = get_next_auth_token(exclude_tokens=failed_tokens)
                                 headers = get_request_headers_with_token(current_token, recaptcha_token)
@@ -4245,8 +4264,29 @@ async def api_chat_completions(request: Request, api_key: dict = Depends(rate_li
                                 yield f"data: {json.dumps(error_chunk)}\n\n"
                                 yield "data: [DONE]\n\n"
                                 return
-                            # The original code has `continue` here, which leads to `async for ka in wait_with_keepalive(2.0): yield ka`.
-                            # This is fine for 401 to allow token rotation and retry.
+                            # Try to refresh the auth token before rotating to next one
+                            if current_token and current_token.startswith("base64-"):
+                                debug_print("🔄 Stream 401: attempting to refresh auth token via LMArena HTTP...")
+                                try:
+                                    refreshed_token = await maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
+                                except Exception:
+                                    refreshed_token = None
+                                if refreshed_token:
+                                    current_token = refreshed_token
+                                    headers = get_request_headers_with_token(current_token, recaptcha_token)
+                                    debug_print("✅ Stream token refreshed successfully, retrying...")
+                                    async for ka in wait_with_keepalive(1.0):
+                                        yield ka
+                                    continue
+                                else:
+                                    debug_print("⚠️ Stream token refresh failed, trying next token...")
+                            # Try next token in rotation
+                            try:
+                                current_token = get_next_auth_token(exclude_tokens=failed_tokens)
+                                headers = get_request_headers_with_token(current_token, recaptcha_token)
+                                debug_print(f"🔄 Stream: retrying with next token: {current_token[:20]}...")
+                            except HTTPException:
+                                debug_print("❌ Stream: no more tokens available after 401.")
                             async for ka in wait_with_keepalive(2.0):
                                 yield ka
                             continue

--- a/tests/test_401_token_refresh.py
+++ b/tests/test_401_token_refresh.py
@@ -1,16 +1,13 @@
 """
 Test that 401 Unauthorized responses trigger token refresh before giving up.
 
-This tests the fix for GitHub issue #172:
-  https://github.com/CloudWaddie/LMArenaBridge/issues/172
-
-The fix uses multiple refresh strategies:
+Tests the fix for GitHub issue #172 via the try_refresh_arena_auth_token helper,
+which uses multiple refresh strategies:
   1) maybe_refresh_expired_auth_tokens (handles already-expired tokens in the pool)
   2) Direct LMArena HTTP refresh via refresh_arena_auth_token_via_lmarena_http
   3) Fall back to next token in rotation
 """
 
-import asyncio
 import json
 import os
 import sys
@@ -18,8 +15,6 @@ import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
-
-import httpx
 
 # Ensure tests can import from the repo root
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -29,8 +24,8 @@ sys.modules["camoufox"] = MagicMock()
 sys.modules["camoufox.async_api"] = MagicMock()
 
 
-class Test401TokenRefresh(unittest.IsolatedAsyncioTestCase):
-    """Tests for the 401 token refresh logic added in issue #172."""
+class TestTryRefreshArenaAuthToken(unittest.IsolatedAsyncioTestCase):
+    """Tests for the try_refresh_arena_auth_token helper function."""
 
     async def asyncSetUp(self):
         import importlib
@@ -50,8 +45,6 @@ class Test401TokenRefresh(unittest.IsolatedAsyncioTestCase):
         self.main.api_key_usage.clear()
 
         self._orig_config_file = self.main.CONFIG_FILE
-        self._orig_token_index = getattr(self.main, "current_token_index", 0)
-
         self._temp_dir = tempfile.TemporaryDirectory()
         self._config_path = Path(self._temp_dir.name) / "config.json"
 
@@ -67,16 +60,14 @@ class Test401TokenRefresh(unittest.IsolatedAsyncioTestCase):
     async def asyncTearDown(self):
         self.main.DEBUG = self._orig_debug
         self.main.CONFIG_FILE = self._orig_config_file
-        if hasattr(self.main, "current_token_index"):
-            self.main.current_token_index = self._orig_token_index
         if self._orig_pytest_current_test is None:
             os.environ.pop("PYTEST_CURRENT_TEST", None)
         else:
             os.environ["PYTEST_CURRENT_TEST"] = self._orig_pytest_current_test
         self._temp_dir.cleanup()
 
-    async def test_401_pool_refresh_succeeds(self):
-        """Strategy 1: maybe_refresh_expired_auth_tokens returns a token."""
+    async def test_pool_refresh_succeeds_does_not_call_direct(self):
+        """Strategy 1: maybe_refresh_expired_auth_tokens returns a token, direct refresh skipped."""
         from src import main
 
         current_token = "base64-dGVzdC10b2tlbg=="
@@ -84,23 +75,12 @@ class Test401TokenRefresh(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock, return_value="base64-pool-refreshed"):
             with patch.object(main, "refresh_arena_auth_token_via_lmarena_http", new_callable=AsyncMock) as mock_direct:
-                with patch.object(main, "get_next_auth_token") as mock_next:
-                    # Simulate the 401 handling logic
-                    refreshed_token = None
-                    if current_token.startswith("base64-"):
-                        refreshed_token = await main.maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
-                        if not refreshed_token:
-                            refreshed_token = await main.refresh_arena_auth_token_via_lmarena_http(current_token)
-                        if refreshed_token:
-                            current_token = refreshed_token
-                            failed_tokens.discard(current_token)
+                result = await main.try_refresh_arena_auth_token(current_token, failed_tokens)
 
-            self.assertEqual(current_token, "base64-pool-refreshed")
-            # Direct refresh should NOT have been called since pool refresh succeeded
-            mock_direct.assert_not_called()
-            mock_next.assert_not_called()
+        self.assertEqual(result, "base64-pool-refreshed")
+        mock_direct.assert_not_called()
 
-    async def test_401_direct_refresh_succeeds_when_pool_fails(self):
+    async def test_pool_fails_direct_succeeds(self):
         """Strategy 2: Pool refresh returns None, direct LMArena HTTP refresh succeeds."""
         from src import main
 
@@ -109,22 +89,13 @@ class Test401TokenRefresh(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock, return_value=None):
             with patch.object(main, "refresh_arena_auth_token_via_lmarena_http", new_callable=AsyncMock, return_value="base64-direct-refreshed") as mock_direct:
-                with patch.object(main, "get_next_auth_token") as mock_next:
-                    refreshed_token = None
-                    if current_token.startswith("base64-"):
-                        refreshed_token = await main.maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
-                        if not refreshed_token:
-                            refreshed_token = await main.refresh_arena_auth_token_via_lmarena_http(current_token)
-                        if refreshed_token:
-                            current_token = refreshed_token
-                            failed_tokens.discard(current_token)
+                result = await main.try_refresh_arena_auth_token(current_token, failed_tokens)
 
-            self.assertEqual(current_token, "base64-direct-refreshed")
-            mock_direct.assert_called_once_with("base64-dGVzdC10b2tlbg==")
-            mock_next.assert_not_called()
+        self.assertEqual(result, "base64-direct-refreshed")
+        mock_direct.assert_called_once_with("base64-dGVzdC10b2tlbg==")
 
-    async def test_401_both_refresh_strategies_fail_falls_back_to_next_token(self):
-        """Strategy 3: Both refresh strategies fail, fall back to get_next_auth_token."""
+    async def test_both_strategies_fail_returns_none(self):
+        """Both refresh strategies fail, function returns None."""
         from src import main
 
         current_token = "base64-dGVzdC10b2tlbg=="
@@ -132,23 +103,12 @@ class Test401TokenRefresh(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock, return_value=None):
             with patch.object(main, "refresh_arena_auth_token_via_lmarena_http", new_callable=AsyncMock, return_value=None):
-                with patch.object(main, "get_next_auth_token", return_value="base64-next-token") as mock_next:
-                    refreshed_token = None
-                    if current_token.startswith("base64-"):
-                        refreshed_token = await main.maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
-                        if not refreshed_token:
-                            refreshed_token = await main.refresh_arena_auth_token_via_lmarena_http(current_token)
-                        if refreshed_token:
-                            current_token = refreshed_token
-                            failed_tokens.discard(current_token)
-                    if not refreshed_token:
-                        current_token = main.get_next_auth_token(exclude_tokens=failed_tokens)
+                result = await main.try_refresh_arena_auth_token(current_token, failed_tokens)
 
-        self.assertEqual(current_token, "base64-next-token")
-        mock_next.assert_called_once_with(exclude_tokens=failed_tokens)
+        self.assertIsNone(result)
 
-    async def test_401_non_base64_token_skips_refresh(self):
-        """Non-base64 tokens should skip all refresh strategies and go straight to next token."""
+    async def test_non_base64_token_returns_none_immediately(self):
+        """Non-base64 tokens skip refresh entirely and return None."""
         from src import main
 
         current_token = "some-plain-token"
@@ -156,40 +116,47 @@ class Test401TokenRefresh(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock) as mock_pool:
             with patch.object(main, "refresh_arena_auth_token_via_lmarena_http", new_callable=AsyncMock) as mock_direct:
-                with patch.object(main, "get_next_auth_token", return_value="next-token") as mock_next:
-                    refreshed_token = None
-                    if current_token.startswith("base64-"):
-                        refreshed_token = await main.maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
-                        if not refreshed_token:
-                            refreshed_token = await main.refresh_arena_auth_token_via_lmarena_http(current_token)
-                    if not refreshed_token:
-                        current_token = main.get_next_auth_token(exclude_tokens=failed_tokens)
+                result = await main.try_refresh_arena_auth_token(current_token, failed_tokens)
 
+        self.assertIsNone(result)
         mock_pool.assert_not_called()
         mock_direct.assert_not_called()
-        self.assertEqual(current_token, "next-token")
 
-    async def test_401_refresh_clears_failed_tokens(self):
-        """After successful refresh, the new token should be removed from failed_tokens."""
+    async def test_empty_token_returns_none(self):
+        """Empty or falsy token returns None immediately."""
+        from src import main
+
+        result = await main.try_refresh_arena_auth_token("", {"some-token"})
+        self.assertIsNone(result)
+
+        result = await main.try_refresh_arena_auth_token(None, {"some-token"})
+        self.assertIsNone(result)
+
+    async def test_pool_refresh_exception_falls_through_to_direct(self):
+        """If maybe_refresh_expired_auth_tokens raises, it should be caught and fall through to direct refresh."""
+        from src import main
+
+        current_token = "base64-dGVzdC10b2tlbg=="
+        failed_tokens = {current_token}
+
+        with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock, side_effect=RuntimeError("pool error")):
+            with patch.object(main, "refresh_arena_auth_token_via_lmarena_http", new_callable=AsyncMock, return_value="base64-direct-refreshed"):
+                result = await main.try_refresh_arena_auth_token(current_token, failed_tokens)
+
+        self.assertEqual(result, "base64-direct-refreshed")
+
+    async def test_direct_refresh_exception_returns_none(self):
+        """If both strategies raise, function returns None."""
         from src import main
 
         current_token = "base64-dGVzdC10b2tlbg=="
         failed_tokens = {current_token}
 
         with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock, return_value=None):
-            with patch.object(main, "refresh_arena_auth_token_via_lmarena_http", new_callable=AsyncMock, return_value="base64-new"):
-                refreshed_token = None
-                if current_token.startswith("base64-"):
-                    refreshed_token = await main.maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
-                    if not refreshed_token:
-                        refreshed_token = await main.refresh_arena_auth_token_via_lmarena_http(current_token)
-                    if refreshed_token:
-                        current_token = refreshed_token
-                        failed_tokens.discard(current_token)
+            with patch.object(main, "refresh_arena_auth_token_via_lmarena_http", new_callable=AsyncMock, side_effect=RuntimeError("direct error")):
+                result = await main.try_refresh_arena_auth_token(current_token, failed_tokens)
 
-        # The old token should still be in failed_tokens, but the new one should not
-        self.assertIn("base64-dGVzdC10b2tlbg==", failed_tokens)
-        self.assertNotIn("base64-new", failed_tokens)
+        self.assertIsNone(result)
 
 
 if __name__ == "__main__":

--- a/tests/test_401_token_refresh.py
+++ b/tests/test_401_token_refresh.py
@@ -4,12 +4,10 @@ Test that 401 Unauthorized responses trigger token refresh before giving up.
 This tests the fix for GitHub issue #172:
   https://github.com/CloudWaddie/LMArenaBridge/issues/172
 
-Before the fix, a 401 would immediately mark the token as failed and try
-the next one. With only one token, this produced:
-  "No more auth tokens available to try" -> "503: Max retries exceeded"
-
-After the fix, the code attempts to refresh the token via LMArena HTTP
-before rotating to the next token.
+The fix uses multiple refresh strategies:
+  1) maybe_refresh_expired_auth_tokens (handles already-expired tokens in the pool)
+  2) Direct LMArena HTTP refresh via refresh_arena_auth_token_via_lmarena_http
+  3) Fall back to next token in rotation
 """
 
 import asyncio
@@ -35,7 +33,6 @@ class Test401TokenRefresh(unittest.IsolatedAsyncioTestCase):
     """Tests for the 401 token refresh logic added in issue #172."""
 
     async def asyncSetUp(self):
-        # Import main fresh for each test to avoid state leakage
         import importlib
         import src.main
         importlib.reload(src.main)
@@ -45,7 +42,6 @@ class Test401TokenRefresh(unittest.IsolatedAsyncioTestCase):
         self._orig_debug = self.main.DEBUG
         self.main.DEBUG = False
 
-        # Skip browser/network startup
         self._orig_pytest_current_test = os.environ.get("PYTEST_CURRENT_TEST")
         if not self._orig_pytest_current_test:
             os.environ["PYTEST_CURRENT_TEST"] = "unittest"
@@ -59,7 +55,6 @@ class Test401TokenRefresh(unittest.IsolatedAsyncioTestCase):
         self._temp_dir = tempfile.TemporaryDirectory()
         self._config_path = Path(self._temp_dir.name) / "config.json"
 
-        # Write a minimal config with a single base64- token
         config = {
             "password": "admin",
             "cf_clearance": "test-cf-clearance",
@@ -80,107 +75,121 @@ class Test401TokenRefresh(unittest.IsolatedAsyncioTestCase):
             os.environ["PYTEST_CURRENT_TEST"] = self._orig_pytest_current_test
         self._temp_dir.cleanup()
 
-    async def test_401_triggers_token_refresh_attempt(self):
-        """When a 401 occurs on a base64- token, maybe_refresh_expired_auth_tokens should be called."""
+    async def test_401_pool_refresh_succeeds(self):
+        """Strategy 1: maybe_refresh_expired_auth_tokens returns a token."""
         from src import main
-
-        refresh_called = False
-
-        async def mock_refresh(exclude_tokens=None):
-            nonlocal refresh_called
-            refresh_called = True
-            return "base64-refreshed-token"
-
-        # Simulate the 401 handling logic from make_request_with_retry (line 2655-2688)
-        current_token = "base64-dGVzdC10b2tlbg=="
-        failed_tokens = set()
-        recaptcha_token = None
-
-        from http import HTTPStatus
-
-        # Simulate receiving a 401 response
-        status_code = 401
-        if status_code == HTTPStatus.UNAUTHORIZED:
-            failed_tokens.add(current_token)
-
-            refreshed_token = None
-            if current_token.startswith("base64-"):
-                refreshed_token = await mock_refresh(exclude_tokens=failed_tokens)
-                if refreshed_token:
-                    current_token = refreshed_token
-
-        self.assertTrue(refresh_called, "maybe_refresh_expired_auth_tokens should have been called on 401")
-        self.assertEqual(current_token, "base64-refreshed-token")
-
-    async def test_401_refresh_failure_falls_back_to_next_token(self):
-        """When refresh returns None, should fall back to get_next_auth_token."""
-        from src import main
-        from http import HTTPStatus
 
         current_token = "base64-dGVzdC10b2tlbg=="
         failed_tokens = {current_token}
-        recaptcha_token = None
+
+        with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock, return_value="base64-pool-refreshed"):
+            with patch.object(main, "refresh_arena_auth_token_via_lmarena_http", new_callable=AsyncMock) as mock_direct:
+                with patch.object(main, "get_next_auth_token") as mock_next:
+                    # Simulate the 401 handling logic
+                    refreshed_token = None
+                    if current_token.startswith("base64-"):
+                        refreshed_token = await main.maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
+                        if not refreshed_token:
+                            refreshed_token = await main.refresh_arena_auth_token_via_lmarena_http(current_token)
+                        if refreshed_token:
+                            current_token = refreshed_token
+                            failed_tokens.discard(current_token)
+
+            self.assertEqual(current_token, "base64-pool-refreshed")
+            # Direct refresh should NOT have been called since pool refresh succeeded
+            mock_direct.assert_not_called()
+            mock_next.assert_not_called()
+
+    async def test_401_direct_refresh_succeeds_when_pool_fails(self):
+        """Strategy 2: Pool refresh returns None, direct LMArena HTTP refresh succeeds."""
+        from src import main
+
+        current_token = "base64-dGVzdC10b2tlbg=="
+        failed_tokens = {current_token}
 
         with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock, return_value=None):
-            with patch.object(main, "get_next_auth_token", return_value="base64-next-token") as mock_next:
-                refreshed_token = None
-                if current_token.startswith("base64-"):
-                    refreshed_token = await main.maybe_refresh_expired_auth_tokens(
-                        exclude_tokens=failed_tokens
-                    )
+            with patch.object(main, "refresh_arena_auth_token_via_lmarena_http", new_callable=AsyncMock, return_value="base64-direct-refreshed") as mock_direct:
+                with patch.object(main, "get_next_auth_token") as mock_next:
+                    refreshed_token = None
+                    if current_token.startswith("base64-"):
+                        refreshed_token = await main.maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
+                        if not refreshed_token:
+                            refreshed_token = await main.refresh_arena_auth_token_via_lmarena_http(current_token)
+                        if refreshed_token:
+                            current_token = refreshed_token
+                            failed_tokens.discard(current_token)
 
-                # Since refresh returned None, should try next token
-                if not refreshed_token:
-                    current_token = main.get_next_auth_token(exclude_tokens=failed_tokens)
+            self.assertEqual(current_token, "base64-direct-refreshed")
+            mock_direct.assert_called_once_with("base64-dGVzdC10b2tlbg==")
+            mock_next.assert_not_called()
+
+    async def test_401_both_refresh_strategies_fail_falls_back_to_next_token(self):
+        """Strategy 3: Both refresh strategies fail, fall back to get_next_auth_token."""
+        from src import main
+
+        current_token = "base64-dGVzdC10b2tlbg=="
+        failed_tokens = {current_token}
+
+        with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock, return_value=None):
+            with patch.object(main, "refresh_arena_auth_token_via_lmarena_http", new_callable=AsyncMock, return_value=None):
+                with patch.object(main, "get_next_auth_token", return_value="base64-next-token") as mock_next:
+                    refreshed_token = None
+                    if current_token.startswith("base64-"):
+                        refreshed_token = await main.maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
+                        if not refreshed_token:
+                            refreshed_token = await main.refresh_arena_auth_token_via_lmarena_http(current_token)
+                        if refreshed_token:
+                            current_token = refreshed_token
+                            failed_tokens.discard(current_token)
+                    if not refreshed_token:
+                        current_token = main.get_next_auth_token(exclude_tokens=failed_tokens)
 
         self.assertEqual(current_token, "base64-next-token")
         mock_next.assert_called_once_with(exclude_tokens=failed_tokens)
 
     async def test_401_non_base64_token_skips_refresh(self):
-        """Non-base64 tokens should skip refresh and go straight to next token."""
+        """Non-base64 tokens should skip all refresh strategies and go straight to next token."""
         from src import main
 
         current_token = "some-plain-token"
         failed_tokens = {current_token}
 
-        with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock) as mock_refresh:
-            with patch.object(main, "get_next_auth_token", return_value="next-token") as mock_next:
-                refreshed_token = None
-                if current_token.startswith("base64-"):
-                    refreshed_token = await main.maybe_refresh_expired_auth_tokens(
-                        exclude_tokens=failed_tokens
-                    )
+        with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock) as mock_pool:
+            with patch.object(main, "refresh_arena_auth_token_via_lmarena_http", new_callable=AsyncMock) as mock_direct:
+                with patch.object(main, "get_next_auth_token", return_value="next-token") as mock_next:
+                    refreshed_token = None
+                    if current_token.startswith("base64-"):
+                        refreshed_token = await main.maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
+                        if not refreshed_token:
+                            refreshed_token = await main.refresh_arena_auth_token_via_lmarena_http(current_token)
+                    if not refreshed_token:
+                        current_token = main.get_next_auth_token(exclude_tokens=failed_tokens)
 
-                if not refreshed_token:
-                    current_token = main.get_next_auth_token(exclude_tokens=failed_tokens)
-
-        # Refresh should NOT have been called for non-base64 token
-        mock_refresh.assert_not_called()
+        mock_pool.assert_not_called()
+        mock_direct.assert_not_called()
         self.assertEqual(current_token, "next-token")
 
-    async def test_401_refresh_success_no_next_token_needed(self):
-        """When refresh succeeds, should NOT call get_next_auth_token."""
+    async def test_401_refresh_clears_failed_tokens(self):
+        """After successful refresh, the new token should be removed from failed_tokens."""
         from src import main
 
         current_token = "base64-dGVzdC10b2tlbg=="
         failed_tokens = {current_token}
 
-        with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock, return_value="base64-new"):
-            with patch.object(main, "get_next_auth_token") as mock_next:
+        with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock, return_value=None):
+            with patch.object(main, "refresh_arena_auth_token_via_lmarena_http", new_callable=AsyncMock, return_value="base64-new"):
                 refreshed_token = None
                 if current_token.startswith("base64-"):
-                    refreshed_token = await main.maybe_refresh_expired_auth_tokens(
-                        exclude_tokens=failed_tokens
-                    )
+                    refreshed_token = await main.maybe_refresh_expired_auth_tokens(exclude_tokens=failed_tokens)
+                    if not refreshed_token:
+                        refreshed_token = await main.refresh_arena_auth_token_via_lmarena_http(current_token)
                     if refreshed_token:
                         current_token = refreshed_token
+                        failed_tokens.discard(current_token)
 
-                # Should NOT have tried next token since refresh succeeded
-                if not refreshed_token:
-                    current_token = main.get_next_auth_token(exclude_tokens=failed_tokens)
-
-        self.assertEqual(current_token, "base64-new")
-        mock_next.assert_not_called()
+        # The old token should still be in failed_tokens, but the new one should not
+        self.assertIn("base64-dGVzdC10b2tlbg==", failed_tokens)
+        self.assertNotIn("base64-new", failed_tokens)
 
 
 if __name__ == "__main__":

--- a/tests/test_401_token_refresh.py
+++ b/tests/test_401_token_refresh.py
@@ -1,0 +1,187 @@
+"""
+Test that 401 Unauthorized responses trigger token refresh before giving up.
+
+This tests the fix for GitHub issue #172:
+  https://github.com/CloudWaddie/LMArenaBridge/issues/172
+
+Before the fix, a 401 would immediately mark the token as failed and try
+the next one. With only one token, this produced:
+  "No more auth tokens available to try" -> "503: Max retries exceeded"
+
+After the fix, the code attempts to refresh the token via LMArena HTTP
+before rotating to the next token.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+# Ensure tests can import from the repo root
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Mock camoufox BEFORE importing src.main (it imports camoufox at module level)
+sys.modules["camoufox"] = MagicMock()
+sys.modules["camoufox.async_api"] = MagicMock()
+
+
+class Test401TokenRefresh(unittest.IsolatedAsyncioTestCase):
+    """Tests for the 401 token refresh logic added in issue #172."""
+
+    async def asyncSetUp(self):
+        # Import main fresh for each test to avoid state leakage
+        import importlib
+        import src.main
+        importlib.reload(src.main)
+        from src import main
+
+        self.main = main
+        self._orig_debug = self.main.DEBUG
+        self.main.DEBUG = False
+
+        # Skip browser/network startup
+        self._orig_pytest_current_test = os.environ.get("PYTEST_CURRENT_TEST")
+        if not self._orig_pytest_current_test:
+            os.environ["PYTEST_CURRENT_TEST"] = "unittest"
+
+        self.main.chat_sessions.clear()
+        self.main.api_key_usage.clear()
+
+        self._orig_config_file = self.main.CONFIG_FILE
+        self._orig_token_index = getattr(self.main, "current_token_index", 0)
+
+        self._temp_dir = tempfile.TemporaryDirectory()
+        self._config_path = Path(self._temp_dir.name) / "config.json"
+
+        # Write a minimal config with a single base64- token
+        config = {
+            "password": "admin",
+            "cf_clearance": "test-cf-clearance",
+            "auth_tokens": ["base64-dGVzdC10b2tlbg=="],
+            "api_keys": [{"name": "Test Key", "key": "test-key", "rpm": 999}],
+        }
+        self._config_path.write_text(json.dumps(config), encoding="utf-8")
+        self.main.CONFIG_FILE = str(self._config_path)
+
+    async def asyncTearDown(self):
+        self.main.DEBUG = self._orig_debug
+        self.main.CONFIG_FILE = self._orig_config_file
+        if hasattr(self.main, "current_token_index"):
+            self.main.current_token_index = self._orig_token_index
+        if self._orig_pytest_current_test is None:
+            os.environ.pop("PYTEST_CURRENT_TEST", None)
+        else:
+            os.environ["PYTEST_CURRENT_TEST"] = self._orig_pytest_current_test
+        self._temp_dir.cleanup()
+
+    async def test_401_triggers_token_refresh_attempt(self):
+        """When a 401 occurs on a base64- token, maybe_refresh_expired_auth_tokens should be called."""
+        from src import main
+
+        refresh_called = False
+
+        async def mock_refresh(exclude_tokens=None):
+            nonlocal refresh_called
+            refresh_called = True
+            return "base64-refreshed-token"
+
+        # Simulate the 401 handling logic from make_request_with_retry (line 2655-2688)
+        current_token = "base64-dGVzdC10b2tlbg=="
+        failed_tokens = set()
+        recaptcha_token = None
+
+        from http import HTTPStatus
+
+        # Simulate receiving a 401 response
+        status_code = 401
+        if status_code == HTTPStatus.UNAUTHORIZED:
+            failed_tokens.add(current_token)
+
+            refreshed_token = None
+            if current_token.startswith("base64-"):
+                refreshed_token = await mock_refresh(exclude_tokens=failed_tokens)
+                if refreshed_token:
+                    current_token = refreshed_token
+
+        self.assertTrue(refresh_called, "maybe_refresh_expired_auth_tokens should have been called on 401")
+        self.assertEqual(current_token, "base64-refreshed-token")
+
+    async def test_401_refresh_failure_falls_back_to_next_token(self):
+        """When refresh returns None, should fall back to get_next_auth_token."""
+        from src import main
+        from http import HTTPStatus
+
+        current_token = "base64-dGVzdC10b2tlbg=="
+        failed_tokens = {current_token}
+        recaptcha_token = None
+
+        with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock, return_value=None):
+            with patch.object(main, "get_next_auth_token", return_value="base64-next-token") as mock_next:
+                refreshed_token = None
+                if current_token.startswith("base64-"):
+                    refreshed_token = await main.maybe_refresh_expired_auth_tokens(
+                        exclude_tokens=failed_tokens
+                    )
+
+                # Since refresh returned None, should try next token
+                if not refreshed_token:
+                    current_token = main.get_next_auth_token(exclude_tokens=failed_tokens)
+
+        self.assertEqual(current_token, "base64-next-token")
+        mock_next.assert_called_once_with(exclude_tokens=failed_tokens)
+
+    async def test_401_non_base64_token_skips_refresh(self):
+        """Non-base64 tokens should skip refresh and go straight to next token."""
+        from src import main
+
+        current_token = "some-plain-token"
+        failed_tokens = {current_token}
+
+        with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock) as mock_refresh:
+            with patch.object(main, "get_next_auth_token", return_value="next-token") as mock_next:
+                refreshed_token = None
+                if current_token.startswith("base64-"):
+                    refreshed_token = await main.maybe_refresh_expired_auth_tokens(
+                        exclude_tokens=failed_tokens
+                    )
+
+                if not refreshed_token:
+                    current_token = main.get_next_auth_token(exclude_tokens=failed_tokens)
+
+        # Refresh should NOT have been called for non-base64 token
+        mock_refresh.assert_not_called()
+        self.assertEqual(current_token, "next-token")
+
+    async def test_401_refresh_success_no_next_token_needed(self):
+        """When refresh succeeds, should NOT call get_next_auth_token."""
+        from src import main
+
+        current_token = "base64-dGVzdC10b2tlbg=="
+        failed_tokens = {current_token}
+
+        with patch.object(main, "maybe_refresh_expired_auth_tokens", new_callable=AsyncMock, return_value="base64-new"):
+            with patch.object(main, "get_next_auth_token") as mock_next:
+                refreshed_token = None
+                if current_token.startswith("base64-"):
+                    refreshed_token = await main.maybe_refresh_expired_auth_tokens(
+                        exclude_tokens=failed_tokens
+                    )
+                    if refreshed_token:
+                        current_token = refreshed_token
+
+                # Should NOT have tried next token since refresh succeeded
+                if not refreshed_token:
+                    current_token = main.get_next_auth_token(exclude_tokens=failed_tokens)
+
+        self.assertEqual(current_token, "base64-new")
+        mock_next.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #172 — the 503/Max retries exceeded error is a symptom of auth tokens returning 401 and the bridge not attempting to refresh them before exhausting retries.

## Changes

4 commits (no merge commits):

1. **attempt token refresh on 401 before failing** — when a request gets 401, try multiple refresh strategies before giving up
2. **unit tests for 401 token refresh logic** — covers pool refresh, direct refresh, fallback to next token, and non-base64 token handling
3. **try direct LMArena HTTP refresh on 401 even for non-expanded tokens** — handles the case where a non-expired token gets invalidated server-side
4. **remove broken anonymous signup from get_initial_data** — that code path relied on reCAPTCHA which fails in headless mode; captures provisional_user_id from cookies instead

## How it works

On 401, the bridge now tries (in order):
1. `maybe_refresh_expired_auth_tokens` — checks if any expired token in the pool can be refreshed via LMArena Set-Cookie or Supabase
2. `refresh_arena_auth_token_via_lmarena_http` — directly refreshes the current token via LMArena HTTP (handles server-side session rotation)
3. Falls back to next token in rotation

This applies both in the pre-stream auth flow and mid-stream when a 401 comes back after connection.